### PR TITLE
S3 refactor to service

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -8,6 +8,12 @@ interface Config {
   publicDir: string
   s3: s3Config,
   allowUpdateLimitDays: number
+  storageService: {
+    host: string
+    port: string
+    user: string
+    password: string
+  }
 }
 
 interface s3Config {
@@ -29,7 +35,13 @@ const testConfig = {
     connection: {rw: {}},
     buckets: {upload: 'cloudnet-upload-test'}
   },
-  allowUpdateLimitDays: 2
+  allowUpdateLimitDays: 2,
+  storageService: {
+    host: 'localhost',
+    port: '5910',
+    user: 'test',
+    password: 'test'
+  }
 }
 
 const devConfig = {
@@ -42,7 +54,13 @@ const devConfig = {
     connection: {rw: {}},
     buckets: {upload: 'cloudnet-upload-dev'}
   },
-  allowUpdateLimitDays: 2
+  allowUpdateLimitDays: 2,
+  storageService: {
+    host: 'localhost',
+    port: '5900',
+    user: 'test',
+    password: 'test'
+  }
 }
 
 let config: Config

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -153,7 +153,7 @@ export class UploadRoutes {
     Promise<{status: number, body: any}> {
 
     let headers = {
-      'Authorization': 'Basic ' +
+      'Authorization': 'Basic ' + // eslint-disable-line prefer-template
       Buffer.from(`${config.storageService.user}:${config.storageService.password}`).toString('base64'),
     }
     if (checksum)

--- a/backend/tests/integration/sequential/upload.test.ts
+++ b/backend/tests/integration/sequential/upload.test.ts
@@ -2,6 +2,8 @@ import axios from 'axios'
 import {Connection, createConnection} from 'typeorm/index'
 import {backendPrivateUrl} from '../../lib'
 import {Status} from '../../../src/entity/Upload'
+import * as express from 'express'
+import {Server} from 'http'
 
 let conn: Connection
 let repo: any
@@ -16,6 +18,7 @@ const validMetadata = {
   instrument: 'mira',
   site: 'granada'
 }
+let server: Server
 
 const str2base64 = (hex: string) =>
   Buffer.from(hex, 'utf8').toString('base64')
@@ -24,7 +27,6 @@ const headers = {'authorization': `Basic ${str2base64('granada:lol')}`}
 beforeAll(async () => {
   conn = await createConnection('test')
   repo = conn.getRepository('upload')
-  return
 })
 
 afterAll(async () => {
@@ -164,6 +166,23 @@ describe('POST /upload/metadata', () => {
 describe('PUT /upload/data/:checksum', () => {
   const validUrl = `${dataUrl}${validMetadata.checksum}`
   const validFile = 'content'
+
+  beforeAll(next => {
+    const app = express()
+    app.put('/cloudnet-upload/*', (req, res, _next) =>{
+      req.on('data', chunk => {
+        if (chunk.toString() == 'content') return res.status(201).send({size: chunk.length})
+        return res.status(400).send('Checksum does not match file contents')
+      })
+    })
+    server = app.listen(5910, next)
+    return
+  })
+
+  afterAll(next => {
+    server.close(next)
+  })
+
   beforeEach(async () => {
     await repo.delete({})
     return axios.post(metadataUrl, validMetadata, {headers})
@@ -195,13 +214,10 @@ describe('PUT /upload/data/:checksum', () => {
     return expect(axios.put(url, validFile, {headers})).rejects.toMatchObject({ response: { status: 400}})
   })
 
-  /*  mock-aws-s3 does not check hashes, so this test will fail. Must test manually.
   test('responds with 400 on incorrect hash', async () => {
     const invalidFile = 'invalid'
     return expect(axios.put(validUrl, invalidFile, {headers})).rejects.toMatchObject({ response: { data: { status: 400}}})
   })
-
-  */
 
   test('responds with 400 on nonexistent hash', async () => {
     const url = `${dataUrl}9a0364b9e99bb480dd25e1f0284c8554`


### PR DESCRIPTION
This PR refactors dataportal to use `storage-service` for file uploads.