### PR TITLE
Use plaintext errors in upload routes

### DIFF
--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -82,7 +82,7 @@ export class UploadRoutes {
           return res.sendStatus(200)
         }
       } catch (err) {
-        return next({ status: 500, errors: err })
+        return next({ status: 500, errors: `Internal server error: ${err.code}` })
       }
     }
 
@@ -105,13 +105,13 @@ export class UploadRoutes {
 
   updateMetadata: RequestHandler = async (req: Request, res: Response, next) => {
     const partialUpload = req.body
-    if (!partialUpload.uuid) return next({status: 422, errors: ['Request body is missing uuid']})
+    if (!partialUpload.uuid) return next({status: 422, errors: 'Request body is missing uuid'})
     try {
       const updateResult = await this.uploadedMetadataRepo.update({uuid: partialUpload.uuid}, partialUpload)
-      if (updateResult.affected == 0) return next({status: 422, errors: ['No file matches the provided uuid']})
+      if (updateResult.affected == 0) return next({status: 422, errors: 'No file matches the provided uuid'})
       res.sendStatus(200)
-    } catch (e) {
-      return next({status: 500, errors: e})
+    } catch (err) {
+      return next({status: 500, errors: `Internal server error: ${err.code}`})
     }
   }
 
@@ -122,14 +122,14 @@ export class UploadRoutes {
         if (uploadedMetadata == undefined) return next({ status: 404, errors: 'No metadata was found with provided id'})
         res.send(this.addS3keyToUpload(uploadedMetadata))
       })
-      .catch(err => next({ status: 500, errors: err}))
+      .catch(err => next({ status: 500, errors: `Internal server error: ${err.code}`}))
   }
 
   listMetadata: RequestHandler = async (req: Request, res: Response, next) => {
     (await this.metadataQueryBuilder(req.query))
       .getMany()
       .then(uploadedMetadata => res.send(uploadedMetadata.map(this.addS3keyToUpload)))
-      .catch(err => {next({status: 500, errors: err})})
+      .catch(err => {next({status: 500, errors: `Internal server error: ${err.code}`})})
   }
 
   listInstrumentsFromMetadata: RequestHandler = async (req: Request, res: Response, next) => {
@@ -159,7 +159,7 @@ export class UploadRoutes {
         return next(err) // Client error
       if (err.errors) // Our error
         return next({status: 500, errors: `Internal server error: ${err.errors}`})
-      return next({status: 500, errors: err}) // Unknown error
+      return next({status: 500, errors: `Internal server error: ${err.code}`}) // Unknown error
     }
   }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -52,6 +52,13 @@ import {DownloadRoutes} from './routes/download'
     next()
   }
 
+  const errorAsPlaintext: ErrorRequestHandler = (err: RequestError | Error, _req, res, next) => {
+    if (!(err instanceof Error)) {
+      err.plaintext = true
+    }
+    next(err)
+  }
+
   if (process.env.NODE_ENV != 'production') {
     app.use(function(_req, res, next) {
       res.header('Access-Control-Allow-Origin', '*')
@@ -109,15 +116,18 @@ import {DownloadRoutes} from './routes/download'
     middleware.getSiteNameFromAuth,
     express.json(),
     uploadRoutes.validateMetadata,
-    uploadRoutes.postMetadata)
+    uploadRoutes.postMetadata,
+    errorAsPlaintext)
   app.put('/upload/data/:checksum',
     middleware.validateMD5Param,
     middleware.getSiteNameFromAuth,
     express.raw({limit: '100gb'}),
-    uploadRoutes.putData)
+    uploadRoutes.putData,
+    errorAsPlaintext)
   app.get('/upload/metadata/:checksum',
     middleware.validateMD5Param,
-    uploadRoutes.metadata)
+    uploadRoutes.metadata,
+    errorAsPlaintext)
 
   // model data upload (for Ewan only)
   app.post('/model-upload/metadata',

--- a/backend/tests/integration/sequential/upload.test.ts
+++ b/backend/tests/integration/sequential/upload.test.ts
@@ -198,12 +198,12 @@ describe('PUT /upload/data/:checksum', () => {
 
   test('responds with 400 on incorrect hash', async () => {
     const invalidFile = 'invalidhash'
-    return expect(axios.put(validUrl, invalidFile, {headers})).rejects.toMatchObject({ response: { data: { status: 400}}})
+    return expect(axios.put(validUrl, invalidFile, {headers})).rejects.toMatchObject({ response: {status: 400}})
   })
 
   test('responds with 500 on internal errors', async () => {
     const invalidFile = 'servererr'
-    return expect(axios.put(validUrl, invalidFile, {headers})).rejects.toMatchObject({ response: { data: { status: 500}}})
+    return expect(axios.put(validUrl, invalidFile, {headers})).rejects.toMatchObject({ response: {status: 500}})
   })
 
   test('responds with 400 on nonexistent hash', async () => {
@@ -215,7 +215,7 @@ describe('PUT /upload/data/:checksum', () => {
     const now = new Date()
     const headers = {'authorization': `Basic ${str2base64('martinlaakso:lol')}`}
     await expect(axios.put(validUrl, validFile, {headers}))
-      .rejects.toMatchObject({ response: { data: { status: 400}}})
+      .rejects.toMatchObject({ response: { status: 400}})
     const md = await repo.findOne({checksum: validMetadata.checksum})
     return expect(new Date(md.updatedAt).getTime()).toBeLessThan(now.getTime())
   })


### PR DESCRIPTION
Use plaintext errors instead of json errors in upload routes.