### PR TITLE
Support for multiple models

### DIFF
--- a/backend/fixtures/2-file.json
+++ b/backend/fixtures/2-file.json
@@ -188,5 +188,41 @@
       "format": "HDF5 (NetCDF4)",
       "site": "bucharest",
       "version": "123"
+    },
+    {
+      "uuid": "b5d1d5af-3667-41bc-b952-e684f627d91c",
+      "pid": "",
+      "volatile": true,
+      "measurementDate": "2020-12-05",
+      "history": "2020-02-17 09:19:16 - global attributes fixed using attribute_modifier 0.0.1\nSun Dec  7 07:35:16 GMT 2014 - NetCDF generated from original data by update_files.pl using cnmodel2nc on anvil2",
+      "product": "model",
+      "model": "ecmwf",
+      "cloudnetpyVersion": "",
+      "createdAt": "2020-02-20T10:52:59.073Z",
+      "updatedAt": "2020-02-20T10:52:59.073Z",
+      "s3key": "20141205_mace-head_ecmwf.nc",
+      "checksum": "055bcd9deae26851992c3da6352844fb9443203c48ae4f4ad8f1aa50ef2ab26f",
+      "size": 500452,
+      "format": "NetCDF3",
+      "site": "bucharest",
+      "version": "123"
+    },
+    {
+      "uuid": "c5d1d5af-3667-41bc-b952-e684f627d91c",
+      "pid": "",
+      "volatile": true,
+      "measurementDate": "2020-12-05",
+      "history": "2020-02-17 09:19:16 - global attributes fixed using attribute_modifier 0.0.1\nSun Dec  7 07:35:16 GMT 2014 - NetCDF generated from original data by update_files.pl using cnmodel2nc on anvil2",
+      "product": "model",
+      "model": "icon-iglo-12-23",
+      "cloudnetpyVersion": "",
+      "createdAt": "2020-02-20T10:52:59.073Z",
+      "updatedAt": "2020-02-20T10:52:59.073Z",
+      "s3key": "20141205_mace-head_ecmwf.nc",
+      "checksum": "155bcd9deae26851992c3da6352844fb9443203c48ae4f4ad8f1aa50ef2ab26f",
+      "size": 500452,
+      "format": "NetCDF3",
+      "site": "bucharest",
+      "version": "123"
     }
 ]

--- a/backend/fixtures/2-file.json
+++ b/backend/fixtures/2-file.json
@@ -190,6 +190,24 @@
       "version": "123"
     },
     {
+      "uuid": "d5d1d5af-3667-41bc-b952-e684f627d91c",
+      "pid": "",
+      "volatile": true,
+      "measurementDate": "2020-12-05",
+      "history": "2020-02-17 09:19:16 - global attributes fixed using attribute_modifier 0.0.1\nSun Dec  7 07:35:16 GMT 2014 - NetCDF generated from original data by update_files.pl using cnmodel2nc on anvil2",
+      "product": "model",
+      "model": "ecmwf",
+      "cloudnetpyVersion": "",
+      "createdAt": "2020-02-20T10:51:59.073Z",
+      "updatedAt": "2020-02-20T10:51:59.073Z",
+      "s3key": "20141205_mace-head_ecmwf.nc",
+      "checksum": "455bcd9deae26851992c3da6352844fb9443203c48ae4f4ad8f1aa50ef2ab26f",
+      "size": 500452,
+      "format": "NetCDF3",
+      "site": "bucharest",
+      "version": "122"
+    },
+    {
       "uuid": "b5d1d5af-3667-41bc-b952-e684f627d91c",
       "pid": "",
       "volatile": true,

--- a/backend/fixtures/2-search_file.json
+++ b/backend/fixtures/2-search_file.json
@@ -71,5 +71,14 @@
       "product": "classification",
       "size": 7127282,
       "site": "bucharest"
+    },
+    {
+      "uuid": "b5d1d5af-3667-41bc-b952-e684f627d91c",
+      "volatile": false,
+      "legacy": false,
+      "measurementDate": "2020-12-05",
+      "product": "model",
+      "size": 500452,
+      "site": "bucharest"
     }
 ]

--- a/backend/src/entity/File.ts
+++ b/backend/src/entity/File.ts
@@ -1,9 +1,21 @@
-import {BeforeInsert, BeforeUpdate, Column, Entity, Index, ManyToOne, OneToMany, PrimaryColumn, Unique} from 'typeorm'
+import {
+    BeforeInsert,
+    BeforeUpdate,
+    Column,
+    Entity,
+    Index, JoinColumn,
+    ManyToOne,
+    OneToMany,
+    OneToOne,
+    PrimaryColumn,
+    Unique
+} from 'typeorm'
 import {Site} from './Site'
 import {Product} from './Product'
 import {Visualization} from './Visualization'
 import {isValidDate} from '../lib'
 import {basename} from 'path'
+import {Model} from './Model'
 
 @Entity()
 @Unique(['checksum'])
@@ -39,6 +51,9 @@ export class File {
 
     @ManyToOne(_ => Product, product => product.files)
     product!: Product
+
+    @ManyToOne(() => Model, {nullable: true})
+    model!: Model
 
     @Column({default: ''})
     cloudnetpyVersion!: string

--- a/backend/src/entity/File.ts
+++ b/backend/src/entity/File.ts
@@ -1,14 +1,13 @@
 import {
-    BeforeInsert,
-    BeforeUpdate,
-    Column,
-    Entity,
-    Index, JoinColumn,
-    ManyToOne,
-    OneToMany,
-    OneToOne,
-    PrimaryColumn,
-    Unique
+  BeforeInsert,
+  BeforeUpdate,
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+  PrimaryColumn,
+  Unique
 } from 'typeorm'
 import {Site} from './Site'
 import {Product} from './Product'

--- a/backend/src/entity/File.ts
+++ b/backend/src/entity/File.ts
@@ -95,7 +95,7 @@ export class File {
     }
 }
 
-export function isFile(obj: any): obj is File {
+export function isFile(obj: any) {
   return 'uuid' in obj
       && 'measurementDate' in obj
       && isValidDate(obj.measurementDate)

--- a/backend/src/entity/Instrument.ts
+++ b/backend/src/entity/Instrument.ts
@@ -20,6 +20,6 @@ export class Instrument {
   @Column()
   humanReadableName!: string
 
-  @OneToMany(_ => Upload, uploadedMetadata => uploadedMetadata.site)
-  uploadedMetadatas!: Upload[]
+  @OneToMany(_ => Upload, upload => upload.site)
+  uploads!: Upload[]
 }

--- a/backend/src/entity/Model.ts
+++ b/backend/src/entity/Model.ts
@@ -1,5 +1,6 @@
 import {Column, Entity, OneToMany, PrimaryColumn} from 'typeorm'
 import {Upload} from './Upload'
+import {File} from './File'
 
 @Entity()
 export class Model {
@@ -10,7 +11,9 @@ export class Model {
     @Column()
     optimumOrder!: number;
 
-    @OneToMany(_ => Upload, uploadedMetadata => uploadedMetadata.site)
-    uploadedMetadatas!: Upload[]
+    @OneToMany(_ => Upload, uploads => uploads.site)
+    uploads!: Upload[]
 
+    @OneToMany(_ => File, file => file.model)
+    files!: File[]
 }

--- a/backend/src/entity/Product.ts
+++ b/backend/src/entity/Product.ts
@@ -21,6 +21,6 @@ export class Product {
     @OneToMany(_ => ProductVariable, prodVar => prodVar.product)
     variables!: ProductVariable[]
 
-    @OneToMany(_ => Upload, uploadedMetadata => uploadedMetadata.site)
-    uploadedMetadatas!: Upload[]
+    @OneToMany(_ => Upload, upload => upload.site)
+    uploads!: Upload[]
 }

--- a/backend/src/entity/Site.ts
+++ b/backend/src/entity/Site.ts
@@ -35,6 +35,6 @@ export class Site {
     @OneToMany(_ => File, file => file.site)
     files!: File[]
 
-    @OneToMany(_ => Upload, uploadedMetadata => uploadedMetadata.site)
-    uploadedMetadatas!: Upload[]
+    @OneToMany(_ => Upload, upload => upload.site)
+    uploads!: Upload[]
 }

--- a/backend/src/entity/Upload.ts
+++ b/backend/src/entity/Upload.ts
@@ -45,10 +45,10 @@ export class Upload {
   @Column()
   updatedAt!: Date
 
-  @ManyToOne(_ => Site, site => site.uploadedMetadatas)
+  @ManyToOne(_ => Site, site => site.uploads)
   site!: Site
 
-  @ManyToOne(_ => Instrument, instrument => instrument.uploadedMetadatas)
+  @ManyToOne(_ => Instrument, instrument => instrument.uploads)
   instrument!: Instrument
 
   @ManyToOne(_ => Model, model => model.uploads)

--- a/backend/src/entity/Upload.ts
+++ b/backend/src/entity/Upload.ts
@@ -51,7 +51,7 @@ export class Upload {
   @ManyToOne(_ => Instrument, instrument => instrument.uploadedMetadatas)
   instrument!: Instrument
 
-  @ManyToOne(_ => Model, model => model.uploadedMetadatas)
+  @ManyToOne(_ => Model, model => model.uploads)
   model!: Model
 
   @BeforeInsert()

--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -47,7 +47,8 @@ export class Middleware {
       return next(requestError)
     }
 
-    let validKeys = ['site', 'volatile', 'product', 'dateFrom', 'dateTo', 'developer', 'releasedBefore', 'allVersions', 'limit', 'showLegacy', 'model', 'allModels']
+    let validKeys = ['site', 'volatile', 'product', 'dateFrom', 'dateTo', 'developer',
+      'releasedBefore', 'allVersions', 'limit', 'showLegacy', 'model', 'allModels']
     if (req.path.includes('visualization')) validKeys.push('variable')
 
     const unknownFields = checkFieldNames(validKeys, req.query)

--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -47,22 +47,15 @@ export class Middleware {
       return next(requestError)
     }
 
-    let validKeys = ['site', 'volatile']
-
-    if (req.path.includes('model')) {
-      validKeys = validKeys.concat(['date', 'model'])
-    }
-    else {
-      validKeys = validKeys.concat(['product', 'dateFrom', 'dateTo', 'developer', 'releasedBefore', 'allVersions', 'limit', 'showLegacy'])
-      if (req.path.includes('visualization')) validKeys.push('variable')
-    }
+    let validKeys = ['site', 'volatile', 'product', 'dateFrom', 'dateTo', 'developer', 'releasedBefore', 'allVersions', 'limit', 'showLegacy', 'model']
+    if (req.path.includes('visualization')) validKeys.push('variable')
 
     const unknownFields = checkFieldNames(validKeys, req.query)
     if (unknownFields.length > 0) {
       requestError.errors.push(`Unknown query parameters: ${unknownFields}`)
     }
 
-    const keys = ['site', 'product', 'dateFrom', 'dateTo', 'volatile', 'limit', 'date', 'model']
+    const keys = ['site', 'product', 'dateFrom', 'dateTo', 'volatile', 'limit', 'date']
     keys.forEach(key => {
       const keyError = this.checkField(key, req.query)
       if (keyError) requestError.errors.push(keyError)

--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -47,7 +47,7 @@ export class Middleware {
       return next(requestError)
     }
 
-    let validKeys = ['site', 'volatile', 'product', 'dateFrom', 'dateTo', 'developer', 'releasedBefore', 'allVersions', 'limit', 'showLegacy', 'model']
+    let validKeys = ['site', 'volatile', 'product', 'dateFrom', 'dateTo', 'developer', 'releasedBefore', 'allVersions', 'limit', 'showLegacy', 'model', 'allModels']
     if (req.path.includes('visualization')) validKeys.push('variable')
 
     const unknownFields = checkFieldNames(validKeys, req.query)

--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -61,6 +61,8 @@ export class Middleware {
       if (keyError) requestError.errors.push(keyError)
     })
 
+    requestError.errors = this.checkModelParamConflicts(requestError.errors, req.query)
+
     if (requestError.errors.length > 0) return next(requestError)
     return next()
   }
@@ -188,5 +190,9 @@ export class Middleware {
     }
   }
 
+  private checkModelParamConflicts = (errors: string[], query: any) => {
+    if (query.allModels && query.model) errors.push('Properties "allModels" and "model" can not be both defined')
+    return errors
+  }
 
 }

--- a/backend/src/migration/1607944893142-AddModelToFile.ts
+++ b/backend/src/migration/1607944893142-AddModelToFile.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddModelToFile1607944893142 implements MigrationInterface {
+    name = 'AddModelToFile1607944893142'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "file" ADD "modelId" character varying`);
+        await queryRunner.query(`ALTER TABLE "file" ADD CONSTRAINT "FK_5af5a3b6962dfdb21c85c530e08" FOREIGN KEY ("modelId") REFERENCES "model"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "file" DROP CONSTRAINT "FK_5af5a3b6962dfdb21c85c530e08"`);
+        await queryRunner.query(`ALTER TABLE "file" DROP COLUMN "modelId"`);
+    }
+
+}

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -173,29 +173,29 @@ export class FileRoutes {
       .andWhere('file.legacy IN (:...showLegacy)', query)
     if (query.allVersions == undefined && query.model == undefined && query.allModels == undefined) {
       qb.innerJoin(sub_qb => // Default functionality
-          sub_qb
-            .from('search_file', 'searchfile'),
-        'best_version',
-        'file.uuid = best_version.uuid')
+        sub_qb
+          .from('search_file', 'searchfile'),
+      'best_version',
+      'file.uuid = best_version.uuid')
     }
     else if (query.allVersions && query.allModels == undefined) {
       qb.innerJoin(sub_qb =>
-          sub_qb
-            .from('file', 'file')
-            .leftJoin('file.model', 'model')
-            .select('MIN(model.optimumOrder)', 'optimum_order')
-            .groupBy('file.site, file.measurementDate, file.product'),
-        'best_model',
-        'model.optimumOrder = best_model.optimum_order')
+        sub_qb
+          .from('file', 'file')
+          .leftJoin('file.model', 'model')
+          .select('MIN(model.optimumOrder)', 'optimum_order')
+          .groupBy('file.site, file.measurementDate, file.product'),
+      'best_model',
+      'model.optimumOrder = best_model.optimum_order')
     }
     else if (query.allModels && query.allVersions == undefined) {
       qb.innerJoin(sub_qb =>
-          sub_qb
-            .from('file', 'file')
-            .select('MAX(file.updatedAt)', 'updated_at')
-            .groupBy('file.site, file.measurementDate, file.product'),
-        'last_version',
-        'file.updatedAt = last_version.updated_at'
+        sub_qb
+          .from('file', 'file')
+          .select('MAX(file.updatedAt)', 'updated_at')
+          .groupBy('file.site, file.measurementDate, file.product'),
+      'last_version',
+      'file.updatedAt = last_version.updated_at'
       )
     }
     else if (query.model) qb.andWhere('model.id IN (:...model)', {model: toArray(query.model)})

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -198,7 +198,7 @@ export class FileRoutes {
       'file.updatedAt = last_version.updated_at'
       )
     }
-    else if (query.model) qb.andWhere('model.id IN (:...model)', {model: toArray(query.model)})
+    else if (query.model) qb.andWhere('model.id IN (:...model)', query)
     qb.orderBy('file.measurementDate', 'DESC')
       .addOrderBy('model.optimumOrder', 'ASC')
       .addOrderBy('file.updatedAt', 'DESC')

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -8,7 +8,7 @@ import {
   convertToSearchResponse,
   getBucketForFile,
   hideTestDataFromNormalUsers,
-  sortByMeasurementDateAsc
+  sortByMeasurementDateAsc, toArray
 } from '../lib'
 import {augmentFiles} from '../lib/'
 import {SearchFile} from '../entity/SearchFile'
@@ -171,7 +171,8 @@ export class FileRoutes {
       .andWhere('file.volatile IN (:...volatile)', query)
       .andWhere('file.updatedAt < :releasedBefore', query)
       .andWhere('file.legacy IN (:...showLegacy)', query)
-    if (query.allVersions == undefined) {
+    if (query.model) qb.andWhere('model.id IN (:...model)', {model: toArray(query.model)})
+    if (query.allVersions == undefined && query.model == undefined) {
       qb.innerJoin(sub_qb =>
         sub_qb
           .from('search_file', 'searchfile'),

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -169,6 +169,13 @@ describe('/api/files', () => {
     return expect(res.data[0]).toMatchObject({ model: {id: 'ecmwf'}})
   })
 
+  it('responds with the specified model file', async () => {
+    const payload = {params: {product: 'model', site: 'bucharest', dateFrom: '2020-12-05', dateTo: '2020-12-05', model: 'icon-iglo-12-23'}}
+    const res = await axios.get(url, payload)
+    expect(res.data).toHaveLength(1)
+    return expect(res.data[0]).toMatchObject({ model: {id: 'icon-iglo-12-23'}})
+  })
+
 })
 
 describe('/api/search', () => {

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -192,6 +192,15 @@ describe('/api/files', () => {
     expect(res.data[1]).toMatchObject({ version: '122'})
   })
 
+  it('responds with 400 if model and allModels are both defined', async () => {
+    const payload = {params: {product: 'model', model: 'ecmwf', allModels: true}}
+    let expectedBody: RequestError = {
+      status: 400,
+      errors: [ 'Properties "allModels" and "model" can not be both defined' ]
+    }
+    return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
+  })
+
 })
 
 describe('/api/search', () => {

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -141,7 +141,7 @@ describe('/api/files', () => {
   it('returns the latest file when limit=1', async () => {
     const res = await axios.get(url, { params: { site: 'bucharest', limit: '1' }})
     expect(res.data).toHaveLength(1)
-    expect(res.data[0].measurementDate).toEqual('2019-07-16')
+    expect(res.data[0].measurementDate).toEqual('2020-12-05')
   })
 
   it('responds with 400 on malformed limit', async () => {

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -162,6 +162,13 @@ describe('/api/files', () => {
     return expect(axios.get(url, payload)).resolves.toMatchObject({data: [{legacy: true}]})
   })
 
+  it('responds with the best model file by default', async () => {
+    const payload = {params: {product: 'model', site: 'bucharest', dateFrom: '2020-12-05', dateTo: '2020-12-05'}}
+    const res = await axios.get(url, payload)
+    expect(res.data).toHaveLength(1)
+    return expect(res.data[0]).toMatchObject({ model: {id: 'ecmwf'}})
+  })
+
 })
 
 describe('/api/search', () => {

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -176,6 +176,22 @@ describe('/api/files', () => {
     return expect(res.data[0]).toMatchObject({ model: {id: 'icon-iglo-12-23'}})
   })
 
+  it('responds with all model files with allModels flag ordered by model quality', async () => {
+    const payload = {params: {product: 'model', site: 'bucharest', dateFrom: '2020-12-05', dateTo: '2020-12-05', allModels: true}}
+    const res = await axios.get(url, payload)
+    expect(res.data).toHaveLength(2)
+    expect(res.data[0]).toMatchObject({ model: {id: 'ecmwf'}})
+    expect(res.data[1]).toMatchObject({ model: {id: 'icon-iglo-12-23'}})
+  })
+
+  it('responds with all versions of best model file when using allVersions', async () => {
+    const payload = {params: {product: 'model', site: 'bucharest', dateFrom: '2020-12-05', dateTo: '2020-12-05', allVersions: true}}
+    const res = await axios.get(url, payload)
+    expect(res.data).toHaveLength(2)
+    expect(res.data[0]).toMatchObject({ version: '123'})
+    expect(res.data[1]).toMatchObject({ version: '122'})
+  })
+
 })
 
 describe('/api/search', () => {

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -61,13 +61,13 @@ describe('/api/files', () => {
   it('responds with 404 if site was not found', () => {
     const payload = {params: {site: ['kilpikonna']}}
     expectedBody404.errors = ['One or more of the specified sites were not found']
-    expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody404.status, expectedBody404))
+    return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody404.status, expectedBody404))
   })
 
   it('responds 404 if one of many sites was not found', () => {
     const payload = {params: {site: ['macehead', 'kilpikonna']}}
     expectedBody404.errors = ['One or more of the specified sites were not found']
-    expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody404.status, expectedBody404))
+    return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody404.status, expectedBody404))
   })
 
   it('responds with an array of objects with dates between [ dateFrom, dateTo ], in descending order', async () => {
@@ -96,7 +96,7 @@ describe('/api/files', () => {
       errors: [ 'Malformed date in property "dateFrom"' ]
     }
     const payload1 = {params: {dateFrom: 'turku'}}
-    expect(axios.get(url, payload1)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
+    return expect(axios.get(url, payload1)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
   })
 
   it('responds with 400 on malformed dateTo', () => {
@@ -105,7 +105,7 @@ describe('/api/files', () => {
       errors: [ 'Malformed date in property "dateTo"' ]
     }
     const payload = {params: {dateFrom: new Date('2020-02-20'), dateTo: 'turku'}}
-    expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
+    return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
   })
 
   it('has exactly three stable files', async () => {
@@ -197,6 +197,24 @@ describe('/api/files', () => {
     let expectedBody: RequestError = {
       status: 400,
       errors: [ 'Properties "allModels" and "model" can not be both defined' ]
+    }
+    return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
+  })
+
+  it('responds with 400 if model and allModels are both defined', async () => {
+    const payload = {params: {product: 'model', model: 'ecmwf', allModels: true}}
+    let expectedBody: RequestError = {
+      status: 400,
+      errors: [ 'Properties "allModels" and "model" can not be both defined' ]
+    }
+    return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
+  })
+
+  it('responds with 404 if a specified model is not found', async () => {
+    const payload = {params: {product: 'model', model: 'sammakko'}}
+    let expectedBody: RequestError = {
+      status: 404,
+      errors: [ 'One or more of the specified models were not found' ]
     }
     return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
   })

--- a/frontend/src/components/DataSearchResult.vue
+++ b/frontend/src/components/DataSearchResult.vue
@@ -206,6 +206,7 @@ export default class DataSearchResult extends Vue {
       .then(({data}) => this.$router.push({path: `/collection/${data}`}))
       .catch(err => {
         this.downloadFailed = true
+        // eslint-disable-next-line no-console
         console.error(err)
       })
       .finally(() => (this.downloadIsBusy = false))

--- a/frontend/src/views/Collection.vue
+++ b/frontend/src/views/Collection.vue
@@ -230,6 +230,7 @@ export default class CollectionView extends Vue {
       })
       .catch(e => {
         this.pidServiceError = true
+        // eslint-disable-next-line no-console
         console.error(e)
       })
       .finally(() => (this.busy = false))
@@ -259,6 +260,7 @@ export default class CollectionView extends Vue {
           this.products = products.data.filter((product: Product) => productIds.includes(product.id))
         })
       })
+      // eslint-disable-next-line no-console
       .catch(console.error)
   }
 }


### PR DESCRIPTION
This PR adds support for different model types.

- Add `model` field to file PUT JSON
- Add `model` parameter for GET `/api/files` for filtering by model id
- Add `allModels` parameter for GET `/api/files` for getting a list of all models
- Minor improvement to the search SQL query.