### PR TITLE
Rename buckets to use new naming schema

### DIFF
--- a/backend/src/lib/index.ts
+++ b/backend/src/lib/index.ts
@@ -81,8 +81,12 @@ export const ssAuthString = () =>
   'Basic ' + // eslint-disable-line prefer-template
   Buffer.from(`${config.storageService.user}:${config.storageService.password}`).toString('base64')
 
+export const addSiteSuffix = (bucket: string, siteid: string) =>
+  `${bucket}-${siteid.replace('-', '')}`
+
 export const getBucketForFile = (file: File) =>
-  file.volatile ? 'cloudnet-product-volatile' : 'cloudnet-product'
+  // file.site is sometimes string, sometimes object
+  addSiteSuffix(file.volatile ? 'cloudnet-product-volatile' : 'cloudnet-product', file.site.id || (file.site as unknown) as string)
 
 export const getS3keyForUpload = (upload: Upload) =>
   `${upload.site.id}/${upload.uuid}/${upload.filename}`

--- a/backend/src/routes/download.ts
+++ b/backend/src/routes/download.ts
@@ -30,7 +30,7 @@ export class DownloadRoutes {
   product: RequestHandler = async (req, res, next) => {
     const s3key = req.params[0]
     try {
-      const file = await this.fileRepo.findOne({uuid: req.params.uuid, s3key})
+      const file = await this.fileRepo.findOne({uuid: req.params.uuid, s3key}, {relations: ['site']})
       if (file === undefined) return next({status: 404, errors: ['File not found']})
       const upstreamRes = await this.makeRequest(file)
       res.setHeader('Content-Type', 'application/octet-stream')
@@ -45,7 +45,7 @@ export class DownloadRoutes {
 
   collection: RequestHandler = async (req, res, next) => {
     const collectionUuid: string = req.params.uuid
-    const collection = await this.collectionRepo.findOne(collectionUuid, {relations: ['files']})
+    const collection = await this.collectionRepo.findOne(collectionUuid, {relations: ['files', 'files.site']})
     if (collection === undefined) {
       return next({status: 404, errors: ['No collection matches this UUID.']})
     }

--- a/backend/tests/e2e/nc2api.test.ts
+++ b/backend/tests/e2e/nc2api.test.ts
@@ -88,7 +88,7 @@ const s3key = `something/${basename(filepath)}`
 
 describe('after PUTting metadata to API', () => {
   beforeAll(async () => {
-    await axios.put(`${storageServiceUrl}cloudnet-product-volatile/${s3key}`, fs.createReadStream(filepath))
+    await axios.put(`${storageServiceUrl}cloudnet-product-volatile-bucharest/${s3key}`, fs.createReadStream(filepath))
     return axios.put(`${backendPrivateUrl}files/${s3key}`, inputJson)
   })
 
@@ -119,7 +119,7 @@ describe('after PUTting metadata to API', () => {
     beforeAll(async () => {
       const filepath = 'tests/data/20190724_bucharest_classification.nc'
       const s3key = basename(filepath)
-      await axios.put(`${storageServiceUrl}cloudnet-product-volatile/${s3key}`, fs.createReadStream(filepath))
+      await axios.put(`${storageServiceUrl}cloudnet-product-volatile-bucharest/${s3key}`, fs.createReadStream(filepath))
       await axios.put(`${backendPrivateUrl}files/${s3key}`, inputJson2)
       const res =  await axios.post(`${backendPublicUrl}collection/`, {files: [expectedJson.uuid, inputJson2.uuid]})
       collectionUuid = res.data

--- a/backend/tests/integration/sequential/file.test.ts
+++ b/backend/tests/integration/sequential/file.test.ts
@@ -20,8 +20,8 @@ beforeAll(async () => {
   searchFileRepo = conn.getRepository('search_file')
   vizRepo = conn.getRepository('visualization')
   return Promise.all([
-    axios.put(`${storageServiceUrl}cloudnet-product-volatile/${volatileFile.s3key}`, 'content'),
-    axios.put(`${storageServiceUrl}cloudnet-product/${stableFile.s3key}`, 'content')
+    axios.put(`${storageServiceUrl}cloudnet-product-volatile-macehead/${volatileFile.s3key}`, 'content'),
+    axios.put(`${storageServiceUrl}cloudnet-product-macehead/${stableFile.s3key}`, 'content')
   ])
 })
 
@@ -95,7 +95,7 @@ describe('PUT /files/:s3key', () => {
     await expect(putFile(tmpfile1)).resolves.toMatchObject({status: 201})
     await expect(fileRepo.findOneOrFail(tmpfile1.uuid, {relations: ['model']})).resolves.toMatchObject({model: {id: tmpfile1.model}})
     await expect(searchFileRepo.findOne(tmpfile1.uuid)).resolves.toBeTruthy()
-    await axios.put(`${storageServiceUrl}cloudnet-product-volatile/${tmpfile2.s3key}`, 'content')
+    await axios.put(`${storageServiceUrl}cloudnet-product-volatile-macehead/${tmpfile2.s3key}`, 'content')
     await expect(putFile(tmpfile2)).resolves.toMatchObject({status: 201})
     await expect(fileRepo.findOneOrFail(tmpfile2.uuid, {relations: ['model']})).resolves.toMatchObject({model: {id: tmpfile2.model}})
     await expect(searchFileRepo.findOne(tmpfile1.uuid)).resolves.toBeFalsy()
@@ -105,10 +105,11 @@ describe('PUT /files/:s3key', () => {
   test('errors on invalid site', async () => {
     const tmpfile = {...stableFile}
     tmpfile.site = 'Bökärest'
-    return expect(putFile(tmpfile)).rejects.toMatchObject({response: { status: 500}})
+    return expect(putFile(tmpfile)).rejects.toMatchObject({response: { status: 400}})
   })
 
   test('overwrites existing freezed files on test site', async () => {
+    await axios.put(`${storageServiceUrl}cloudnet-product-granada/${stableFile.s3key}`, 'content')
     const tmpfile = {...stableFile}
     tmpfile.site = 'granada'
     await putFile(tmpfile)
@@ -125,7 +126,7 @@ describe('PUT /files/:s3key', () => {
     tmpfile.uuid = '62b32746-faf0-4057-9076-ed2e698dcc34'
     tmpfile.checksum = 'dc460da4ad72c482231e28e688e01f2778a88ce31a08826899d54ef7183998b5'
     tmpfile.s3key = 'sourcefiles.nc'
-    await axios.put(`${storageServiceUrl}cloudnet-product/${tmpfile.s3key}`, 'content')
+    await axios.put(`${storageServiceUrl}cloudnet-product-macehead/${tmpfile.s3key}`, 'content')
     await expect(putFile(tmpfile)).resolves.toMatchObject({status: 201})
     const dbRow1 = await fileRepo.findOneOrFail(tmpfile.uuid)
     return expect(dbRow1.sourceFileIds).toMatchObject([stableFile.uuid])

--- a/backend/tests/lib/index.ts
+++ b/backend/tests/lib/index.ts
@@ -21,9 +21,10 @@ export async function clearRepo(repo: string) {
 }
 
 export async function putFile(filename: string) {
+  const site = filename.split('_')[1].replace('-', '')
   await Promise.all([
-    axios.put(`${storageServiceUrl}cloudnet-product-volatile/${filename}`, 'content'),
-    axios.put(`${storageServiceUrl}cloudnet-product/${filename}`, 'content')
+    axios.put(`${storageServiceUrl}cloudnet-product-volatile-${site}/${filename}`, 'content'),
+    axios.put(`${storageServiceUrl}cloudnet-product-${site}/${filename}`, 'content')
   ])
   const json = JSON.parse(fs.readFileSync(`tests/data/${filename}.json`, 'utf8'))
   const url = `${backendPrivateUrl}files/${filename}`
@@ -34,8 +35,6 @@ export const wait = async (ms: number) => new Promise((resolve, _) => setTimeout
 
 export const genResponse = (status: any, data: any) => ({response: {status, data}})
 
-export const inboxDir = 'tests/data/inbox'
-export const inboxSubDir = 'tests/data/inbox/inbox'
 export const publicDir = 'tests/data/public'
 export const backendProtectedUrl = 'http://localhost:3001/protected/'
 export const backendPublicUrl = 'http://localhost:3001/api/'


### PR DESCRIPTION
Use site ids with dashes omitted as a suffix for all bucket names.