### PR TITLE
Stream query results

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7840,6 +7840,11 @@
          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
          "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
       },
+      "pg-cursor": {
+         "version": "2.5.2",
+         "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.5.2.tgz",
+         "integrity": "sha512-yS0lxXA5WoIVK7BUgJr1uOJDJe5JxVezItTLvqnTXj6bF3di4UtQOrPx8RW3GpFmom2NTQfpEc2N6vvdpopQSw=="
+      },
       "pg-int8": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -7854,6 +7859,14 @@
          "version": "2.0.10",
          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
          "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+      },
+      "pg-query-stream": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.0.0.tgz",
+         "integrity": "sha512-Jftit2EUBn+ilh4JtAgw0JXKR54vATmYHlZ4fmIlbZgL1qT/GKUuwMzLFT8QQm+qJHZwlRIIfkMUOP7soY38ag==",
+         "requires": {
+            "pg-cursor": "^2.5.2"
+         }
       },
       "pg-types": {
          "version": "2.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
       "mock-aws-s3": "^4.0.1",
       "nodemon": "^2.0.4",
       "pg": "^7.18.2",
+      "pg-query-stream": "^4.0.0",
       "reflect-metadata": "^0.1.10",
       "sass": "^1.26.8",
       "typeorm": "^0.2.25",

--- a/backend/src/entity/CollectionResponse.ts
+++ b/backend/src/entity/CollectionResponse.ts
@@ -16,7 +16,7 @@ export class CollectionResponse {
     const sortedFiles = coll.files.concat(coll.modelFiles)
       .sort((a, b) => a.measurementDate > b.measurementDate ? 1 : -1)
     this.uuid = coll.uuid
-    this.files = convertToSearchResponse(sortedFiles)
+    this.files = sortedFiles.map(convertToSearchResponse)
     this.title = coll.title
     this.pid = coll.pid
     this.downloadCount = coll.downloadCount

--- a/backend/src/lib/index.ts
+++ b/backend/src/lib/index.ts
@@ -70,12 +70,12 @@ export const sortByMeasurementDateAsc = <T extends File|SearchFile>(files: T[]):
   files.sort((a, b) => new Date(a.measurementDate).getTime() - new Date(b.measurementDate).getTime())
 
 export const augmentFile = (file: File|RegularFile|ModelFile) => ({
-    ...file,
-    downloadUrl: `${config.downloadBaseUrl}${getDownloadPathForFile(file)}`,
-    filename: basename(file.s3key),
-    s3key: undefined,
-    model: 'model' in file ? file.model : undefined
-  })
+  ...file,
+  downloadUrl: `${config.downloadBaseUrl}${getDownloadPathForFile(file)}`,
+  filename: basename(file.s3key),
+  s3key: undefined,
+  model: 'model' in file ? file.model : undefined
+})
 
 export const ssAuthString = () =>
   'Basic ' + // eslint-disable-line prefer-template
@@ -109,7 +109,6 @@ const translateKeyVal = (key: string, val: string|number|boolean|Date, acc: any)
       ...{ [subKey]: val }
     }
   }
-
 }
 
 export const transformRawFile = (obj: any): RegularFile|ModelFile|SearchFile => {

--- a/backend/src/routes/collection.ts
+++ b/backend/src/routes/collection.ts
@@ -85,7 +85,7 @@ export class CollectionRoutes {
   allcollections: RequestHandler = async (req: Request, res: Response, next) =>
     this.collectionRepo.find({ relations: ['files', 'files.product', 'files.site'] })
       .then(collections => {
-        const response = collections.map(coll => ({...coll, ...{files: convertToSearchResponse(coll.files)}}))
+        const response = collections.map(coll => ({...coll, ...{files: coll.files.map(convertToSearchResponse)}}))
         res.send(response)
       })
       .catch(err => next({ status: 500, errors: err }))

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -16,7 +16,6 @@ import {Model} from '../entity/Model'
 import {basename} from 'path'
 import {ModelFile} from '../entity/File'
 import ReadableStream = NodeJS.ReadableStream
-import {SearchFileResponse} from '../entity/SearchFileResponse'
 
 export class FileRoutes {
 

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -289,7 +289,7 @@ describe('/api/search', () => {
       errors: [ 'The search yielded zero results' ]
     }
     const payload = {params: {date: '2021-01-22'}}
-    return expect(axios.get(url, payload)).rejects.toMatchObject(genResponse(expectedBody.status, expectedBody))
+    return expect(axios.get(url, payload)).resolves.toHaveLength(0)
   })
 
   it('returns the latest file when limit=1', async () => {

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -284,10 +284,6 @@ describe('/api/search', () => {
   })
 
   it('does not return hidden sites', async () => {
-    let expectedBody: RequestError = {
-      status: 404,
-      errors: [ 'The search yielded zero results' ]
-    }
     const payload = {params: {date: '2021-01-22'}}
     return expect(axios.get(url, payload)).resolves.toHaveLength(0)
   })


### PR DESCRIPTION
Stream query results for
- `GET /api/files`
- `GET /api/model-files`
- `GET /api/search`

This should fix backend crashing on large queries.