### PR TITLE
Get rid of allowupdate

### DIFF
--- a/backend/fixtures/2-model_upload.json
+++ b/backend/fixtures/2-model_upload.json
@@ -7,7 +7,6 @@
     "site": "granada",
     "status": "created",
     "size": 80,
-    "allowUpdate": true,
     "createdAt": "2020-09-28T12:47:21.916Z",
     "updatedAt": "2020-09-28T12:47:21.916Z",
     "model": "ecmwf"
@@ -20,7 +19,6 @@
     "site": "mace-head",
     "status": "created",
     "size": 70,
-    "allowUpdate": true,
     "createdAt": "2020-09-28T12:47:21.916Z",
     "updatedAt": "2020-09-28T12:47:21.916Z",
     "model": "ecmwf"
@@ -32,7 +30,6 @@
     "measurementDate": "2018-01-26",
     "site": "granada",
     "status": "created",
-    "allowUpdate": true,
     "size": 60,
     "createdAt": "2020-09-28T12:47:21.916Z",
     "updatedAt": "2020-09-28T12:47:21.916Z",
@@ -46,7 +43,6 @@
     "site": "bucharest",
     "status": "processed",
     "size": 50,
-    "allowUpdate": true,
     "createdAt": "2020-09-28T12:47:21.916Z",
     "updatedAt": "2020-09-28T12:47:21.916Z",
     "model": "icon-iglo-12-23"

--- a/backend/src/entity/Upload.ts
+++ b/backend/src/entity/Upload.ts
@@ -1,8 +1,7 @@
-import {Column, Entity, ManyToOne, PrimaryColumn} from 'typeorm/index'
+import {BeforeInsert, BeforeUpdate, Column, Entity, ManyToOne, PrimaryColumn} from 'typeorm'
 import {Site} from './Site'
 import {Instrument} from './Instrument'
 import {Model} from './Model'
-import {BeforeInsert, BeforeUpdate} from 'typeorm'
 import {v4 as generateUuidV4} from 'uuid'
 
 export enum Status {
@@ -36,9 +35,6 @@ export abstract class Upload {
   })
   status!: Status
 
-  @Column({default: false})
-  allowUpdate!: boolean
-
   @Column()
   createdAt!: Date
 
@@ -64,7 +60,6 @@ export abstract class Upload {
     filename: string,
     date: string,
     site: Site,
-    allowUpdate: boolean,
     status: Status,
   ) {
     this.uuid = generateUuidV4()
@@ -72,7 +67,6 @@ export abstract class Upload {
     this.filename = filename
     this.measurementDate = new Date(date)
     this.site = site
-    this.allowUpdate = allowUpdate
     this.status = status
   }
 }
@@ -83,8 +77,8 @@ export class InstrumentUpload extends Upload {
   @ManyToOne(_ => Instrument, instrument => instrument.uploads)
   instrument!: Instrument
 
-  constructor(checksum: string, filename: string, date: string, site: Site, allowUpdate: boolean, status: Status, instrument: Instrument) { // eslint-disable-line max-len
-    super(checksum, filename, date, site, allowUpdate, status)
+  constructor(checksum: string, filename: string, date: string, site: Site, status: Status, instrument: Instrument) { // eslint-disable-line max-len
+    super(checksum, filename, date, site, status)
     this.instrument = instrument
   }
 }
@@ -97,8 +91,8 @@ export class ModelUpload extends Upload {
   @ManyToOne(_ => Model, model => model.uploads)
   model!: Model
 
-  constructor(checksum: string, filename: string, date: string, site: Site, allowUpdate: boolean, status: Status, model: Model) { // eslint-disable-line max-len
-    super(checksum, filename, date, site, allowUpdate, status)
+  constructor(checksum: string, filename: string, date: string, site: Site, status: Status, model: Model) { // eslint-disable-line max-len
+    super(checksum, filename, date, site, status)
     this.model = model
   }
 }

--- a/backend/src/migration/1616417210757-RemoveAllowUpdate.ts
+++ b/backend/src/migration/1616417210757-RemoveAllowUpdate.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class RemoveAllowUpdate1616417210757 implements MigrationInterface {
+    name = 'RemoveAllowUpdate1616417210757'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "upload" DROP COLUMN "allowUpdate"`);
+        await queryRunner.query(`ALTER TABLE "instrument_upload" DROP COLUMN "allowUpdate"`);
+        await queryRunner.query(`ALTER TABLE "model_upload" DROP COLUMN "allowUpdate"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "model_upload" ADD "allowUpdate" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "instrument_upload" ADD "allowUpdate" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "upload" ADD "allowUpdate" boolean NOT NULL DEFAULT false`);
+    }
+
+}

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -107,7 +107,7 @@ export class UploadRoutes {
     // With allowUpdate flag (and no stable files), keep existing uuid to avoid duplicate files
     if (allowUpdate) {
       try {
-        const existingMetadata = await uploadRepo.findOne({filename: filename, allowUpdate: true})
+        const existingMetadata = await uploadRepo.findOne({filename: filename})
         if (existingMetadata != undefined) {
           await uploadRepo.update(existingMetadata.uuid, {
             checksum: body.checksum,
@@ -128,7 +128,6 @@ export class UploadRoutes {
         filename,
         body.measurementDate,
         site,
-        allowUpdate,
         Status.CREATED,
       instrument as Instrument)
     } else {
@@ -137,7 +136,6 @@ export class UploadRoutes {
         filename,
         body.measurementDate,
         site,
-        allowUpdate,
         Status.CREATED,
       model as Model)
     }

--- a/backend/tests/integration/sequential/upload.test.ts
+++ b/backend/tests/integration/sequential/upload.test.ts
@@ -103,12 +103,13 @@ describe('POST /upload/metadata', () => {
 
   test('updates existing metadata', async () => {
     const payload = {...validMetadata}
-    await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
+    const expectedResponse = {status: 200, data: 'OK'}
+    await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject(expectedResponse)
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     expect(md.checksum).toBe(validMetadata.checksum)
     const initial_time = new Date(md.updatedAt).getTime()
     const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
+    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject(expectedResponse)
     expect(await instrumentRepo.findOne({checksum: payload.checksum})).toBe(undefined)
     const md_resub = await instrumentRepo.findOne(md.uuid)
     expect(md_resub.checksum).toBe(payload_resub.checksum)
@@ -138,11 +139,12 @@ describe('POST /upload/metadata', () => {
 
   test('updates existing metadata with allowUpdate = true', async () => {
     const payload = {...validMetadata, allowUpdate: true}
-    await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
+    const expectedResponse = {status: 200, data: 'Warning: Ignoring obsolete allowUpdate property'}
+    await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject(expectedResponse)
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     expect(md.checksum).toBe(validMetadata.checksum)
     const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
+    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject(expectedResponse)
     expect(await instrumentRepo.findOne({checksum: payload.checksum})).toBe(undefined)
     const md_resub = await instrumentRepo.findOne(md.uuid)
     return expect(md_resub.checksum).toBe(payload_resub.checksum)
@@ -150,11 +152,12 @@ describe('POST /upload/metadata', () => {
 
   test('updates existing metadata with allowUpdate = false', async () => {
     const payload = {...validMetadata, allowUpdate: false}
-    await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
+    const expectedResponse = {status: 200, data: 'Warning: Ignoring obsolete allowUpdate property'}
+    await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject(expectedResponse)
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     expect(md.checksum).toBe(validMetadata.checksum)
     const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
+    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject(expectedResponse)
     expect(await instrumentRepo.findOne({checksum: payload.checksum})).toBe(undefined)
     const md_resub = await instrumentRepo.findOne(md.uuid)
     return expect(md_resub.checksum).toBe(payload_resub.checksum)

--- a/backend/tests/integration/sequential/upload.test.ts
+++ b/backend/tests/integration/sequential/upload.test.ts
@@ -86,19 +86,28 @@ describe('POST /upload/metadata', () => {
   test('inserts new metadata if different date', async () => {
     const payload = {...validMetadata}
     await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
-    const payload_resub = {...payload, measurementDate: '2020-08-12', checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
+    const payloadResub = {...payload, measurementDate: '2020-08-12', checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject({status: 200})
     await instrumentRepo.findOneOrFail({checksum: payload.checksum})
-    return await instrumentRepo.findOneOrFail({checksum: payload_resub.checksum})
+    return await instrumentRepo.findOneOrFail({checksum: payloadResub.checksum})
   })
 
   test('inserts new metadata if different filename', async () => {
     const payload = {...validMetadata}
     await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
-    const payload_resub = {...payload, filename: 'random_results.nc', checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
+    const payloadResub = {...payload, filename: 'random_results.nc', checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject({status: 200})
     await instrumentRepo.findOneOrFail({checksum: payload.checksum})
-    return await instrumentRepo.findOneOrFail({checksum: payload_resub.checksum})
+    return await instrumentRepo.findOneOrFail({checksum: payloadResub.checksum})
+  })
+
+  test('inserts new metadata if different instrument', async () => {
+    const payload = {...validMetadata}
+    await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
+    const payloadResub = {...payload, instrument: 'hatpro', checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject({status: 200})
+    await instrumentRepo.findOneOrFail({checksum: payload.checksum})
+    return await instrumentRepo.findOneOrFail({checksum: payloadResub.checksum})
   })
 
   test('updates existing metadata', async () => {
@@ -107,22 +116,22 @@ describe('POST /upload/metadata', () => {
     await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject(expectedResponse)
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     expect(md.checksum).toBe(validMetadata.checksum)
-    const initial_time = new Date(md.updatedAt).getTime()
-    const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject(expectedResponse)
+    const initialTime = new Date(md.updatedAt).getTime()
+    const payloadResub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject(expectedResponse)
     expect(await instrumentRepo.findOne({checksum: payload.checksum})).toBe(undefined)
-    const md_resub = await instrumentRepo.findOne(md.uuid)
-    expect(md_resub.checksum).toBe(payload_resub.checksum)
-    const resub_time = new Date(md_resub.updatedAt).getTime()
-    return expect(resub_time).toBeGreaterThan(initial_time)
+    const mdResub = await instrumentRepo.findOne(md.uuid)
+    expect(mdResub.checksum).toBe(payloadResub.checksum)
+    const ResubTime = new Date(mdResub.updatedAt).getTime()
+    return expect(ResubTime).toBeGreaterThan(initialTime)
   })
 
   test('updates existing metadata if stable product', async () => {
     const payload = {...validMetadataAndStableProduct}
     await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
-    const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
-    await instrumentRepo.findOneOrFail({checksum: payload_resub.checksum})
+    const payloadResub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject({status: 200})
+    await instrumentRepo.findOneOrFail({checksum: payloadResub.checksum})
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     return expect(md).toBe(undefined)
   })
@@ -130,9 +139,9 @@ describe('POST /upload/metadata', () => {
   test('updates existing metadata if volatile product', async () => {
     const payload = {...validMetadataAndVolatileProduct}
     await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
-    const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
-    await instrumentRepo.findOneOrFail({checksum: payload_resub.checksum})
+    const payloadResub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject({status: 200})
+    await instrumentRepo.findOneOrFail({checksum: payloadResub.checksum})
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     return expect(md).toBe(undefined)
   })
@@ -143,11 +152,11 @@ describe('POST /upload/metadata', () => {
     await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject(expectedResponse)
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     expect(md.checksum).toBe(validMetadata.checksum)
-    const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject(expectedResponse)
+    const payloadResub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject(expectedResponse)
     expect(await instrumentRepo.findOne({checksum: payload.checksum})).toBe(undefined)
-    const md_resub = await instrumentRepo.findOne(md.uuid)
-    return expect(md_resub.checksum).toBe(payload_resub.checksum)
+    const mdResub = await instrumentRepo.findOne(md.uuid)
+    return expect(mdResub.checksum).toBe(payloadResub.checksum)
   })
 
   test('updates existing metadata with allowUpdate = false', async () => {
@@ -156,11 +165,11 @@ describe('POST /upload/metadata', () => {
     await expect(axios.post(metadataUrl, payload, {headers})).resolves.toMatchObject(expectedResponse)
     const md = await instrumentRepo.findOne({checksum: payload.checksum})
     expect(md.checksum).toBe(validMetadata.checksum)
-    const payload_resub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
-    await expect(axios.post(metadataUrl, payload_resub, {headers})).resolves.toMatchObject(expectedResponse)
+    const payloadResub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(metadataUrl, payloadResub, {headers})).resolves.toMatchObject(expectedResponse)
     expect(await instrumentRepo.findOne({checksum: payload.checksum})).toBe(undefined)
-    const md_resub = await instrumentRepo.findOne(md.uuid)
-    return expect(md_resub.checksum).toBe(payload_resub.checksum)
+    const mdResub = await instrumentRepo.findOne(md.uuid)
+    return expect(mdResub.checksum).toBe(payloadResub.checksum)
   })
 
   test('responds with 200 on existing hashsum with created status', async () => {
@@ -357,11 +366,10 @@ describe('POST /model-upload/metadata', () => {
     await expect(axios.post(modelMetadataUrl, payload, {headers})).resolves.toMatchObject({status: 200})
     const md = await modelRepo.findOne({checksum: payload.checksum})
     await modelRepo.update(md.uuid, {updatedAt: '2020-11-07'})
-    const new_checksum = 'ac5c1f6c923cc8b259c2e22c7b258ee4'
-    const payload_resub = {...payload, checksum: new_checksum}
-    await expect(axios.post(modelMetadataUrl, payload_resub, {headers})).resolves.toMatchObject({status: 200})
-    const md_resub = await modelRepo.findOne(md.uuid)
-    return expect(md_resub.checksum).toBe(new_checksum)
+    const payloadResub = {...payload, checksum: 'ac5c1f6c923cc8b259c2e22c7b258ee4'}
+    await expect(axios.post(modelMetadataUrl, payloadResub, {headers})).resolves.toMatchObject({status: 200})
+    const mdResub = await modelRepo.findOne(md.uuid)
+    return expect(mdResub.checksum).toBe(payloadResub.checksum)
   })
 
   test('responds with 409 on existing hashsum with allowUpdate=True', async () => {

--- a/docs/data-upload.md
+++ b/docs/data-upload.md
@@ -21,15 +21,6 @@ The JSON request should have the following fields:
 - `checksum`: An MD5 sum of the file being sent. Used for identifying the file and verifying its integrity. 
   Can be computed by using for instance the `md5sum` UNIX program.
 
-In addition to the mandatory fields above, there is one optional field:
-
-- `allowUpdate`: Setting this to `true` indicates that the same filename is going to be sent multiple times.
-  The value should be `true` also in the subsequent submissions.
-  Used in real-time data transfer with instruments that append data to a single daily file
-  instead of providing multiple static files per day. Default is `false`, when a new version of
-  the file is saved regardless of filename.
-**Do not set this flag if your file is complete, and you only submit it once!**
-
 Example JSON for uploading a file named `201030_020000_P06_ZEN.LV1`:
 
 ```json

--- a/shared/res/uploaded-metadata.json
+++ b/shared/res/uploaded-metadata.json
@@ -13,7 +13,6 @@
       "gaw": "UGR",
       "country": "Spain"
     },
-    "allowUpdate": false,
     "status": "created",
     "size": 30,
     "createdAt": "2020-09-28T12:45:21.916Z",
@@ -39,7 +38,6 @@
       "gaw": "Unknown",
       "country": "Romania"
     },
-    "allowUpdate": false,
     "status": "processed",
     "size": 20,
     "createdAt": "2020-09-28T12:47:21.916Z",
@@ -65,7 +63,6 @@
       "gaw": "Unknown",
       "country": "Romania"
     },
-    "allowUpdate": false,
     "status": "processed",
     "size": 10,
     "createdAt": "2020-09-28T12:46:21.916Z",
@@ -91,7 +88,6 @@
       "gaw": "Unknown",
       "country": "Romania"
     },
-    "allowUpdate": false,
     "status": "uploaded",
     "size": 0,
     "createdAt": "2020-09-28T12:48:21.916Z",

--- a/shared/res/uploaded-model-metadata.json
+++ b/shared/res/uploaded-model-metadata.json
@@ -13,7 +13,6 @@
       "gaw": "UGR",
       "country": "Spain"
     },
-    "allowUpdate": true,
     "status": "created",
     "size": 80,
     "createdAt": "2020-09-28T12:47:21.916Z",
@@ -38,7 +37,6 @@
       "gaw": "MHD",
       "country": "Ireland"
     },
-    "allowUpdate": true,
     "status": "created",
     "size": 70,
     "createdAt": "2020-09-28T12:47:21.916Z",
@@ -63,7 +61,6 @@
       "gaw": "UGR",
       "country": "Spain"
     },
-    "allowUpdate": true,
     "status": "created",
     "size": 60,
     "createdAt": "2020-09-28T12:47:21.916Z",
@@ -88,7 +85,6 @@
       "gaw": "Unknown",
       "country": "Romania"
     },
-    "allowUpdate": true,
     "status": "processed",
     "size": 50,
     "createdAt": "2020-09-28T12:47:21.916Z",
@@ -113,7 +109,6 @@
       "gaw": "UGR",
       "country": "Spain"
     },
-    "allowUpdate": false,
     "status": "uploaded",
     "size": 40,
     "createdAt": "2020-09-28T12:47:21.916Z",


### PR DESCRIPTION
This PR removes `allowUpdate` property from file submission metadata. Behavior now:
- Instrument files can be updated infinitely as long as `site`, `measurementDate` and `filename` match.
- Model files can be updated until stable product arrives (no change).