### PR TITLE
Add table for misc uploads

### DIFF
--- a/backend/fixtures/2-instrument.json
+++ b/backend/fixtures/2-instrument.json
@@ -33,5 +33,10 @@
     "id": "hatpro",
     "type": "mwr",
     "humanReadableName": "RPG HATPRO microwave radiometer"
+  },
+  {
+    "id": "halo-doppler-lidar",
+    "type": "lidar",
+    "humanReadableName": "Halo Photonics Doppler lidar"
   }
 ]

--- a/backend/fixtures/2-instrument.json
+++ b/backend/fixtures/2-instrument.json
@@ -37,6 +37,7 @@
   {
     "id": "halo-doppler-lidar",
     "type": "lidar",
-    "humanReadableName": "Halo Photonics Doppler lidar"
+    "humanReadableName": "Halo Photonics Doppler lidar",
+    "auxiliary": true
   }
 ]

--- a/backend/src/entity/Instrument.ts
+++ b/backend/src/entity/Instrument.ts
@@ -18,6 +18,9 @@ export class Instrument {
   @Column()
   type!: InstrumentType
 
+  @Column({default: false})
+  auxiliary!: boolean
+
   @Column()
   humanReadableName!: string
 

--- a/backend/src/entity/Upload.ts
+++ b/backend/src/entity/Upload.ts
@@ -97,3 +97,15 @@ export class ModelUpload extends Upload {
   }
 }
 
+@Entity()
+export class MiscUpload extends Upload {
+
+  @ManyToOne(_ => Instrument, instrument => instrument.uploads)
+  instrument!: Instrument
+
+  constructor(checksum: string, filename: string, date: string, site: Site, status: Status, instrument: Instrument) { // eslint-disable-line max-len
+    super(checksum, filename, date, site, status)
+    this.instrument = instrument
+  }
+}
+

--- a/backend/src/lib/index.ts
+++ b/backend/src/lib/index.ts
@@ -1,6 +1,6 @@
 import {Connection, Repository, SelectQueryBuilder} from 'typeorm'
 import {basename} from 'path'
-import {NextFunction, Request, RequestHandler, Response} from 'express'
+import {NextFunction, Request, Response} from 'express'
 import {ModelFile, RegularFile} from '../entity/File'
 import {File} from '../entity/File'
 import {SearchFileResponse} from '../entity/SearchFileResponse'

--- a/backend/src/migration/1624874560716-AddMiscUpload.ts
+++ b/backend/src/migration/1624874560716-AddMiscUpload.ts
@@ -1,0 +1,22 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddMiscUpload1624874560716 implements MigrationInterface {
+    name = 'AddMiscUpload1624874560716'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "misc_upload_status_enum" AS ENUM('created', 'uploaded', 'processed')`);
+        await queryRunner.query(`CREATE TABLE "misc_upload" ("uuid" uuid NOT NULL, "checksum" character varying(32) NOT NULL, "filename" character varying NOT NULL, "measurementDate" date NOT NULL, "size" bigint NOT NULL DEFAULT '0', "status" "misc_upload_status_enum" NOT NULL DEFAULT 'created', "createdAt" TIMESTAMP NOT NULL, "updatedAt" TIMESTAMP NOT NULL, "siteId" character varying, "instrumentId" character varying, CONSTRAINT "UQ_99f80376751ecbc18b658b38bda" UNIQUE ("checksum"), CONSTRAINT "PK_6b0d2e9e249b032d9aa259cae58" PRIMARY KEY ("uuid"))`);
+        await queryRunner.query(`ALTER TABLE "instrument" ADD "auxiliary" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "misc_upload" ADD CONSTRAINT "FK_23a6d85d68e4902c1769ef37c7e" FOREIGN KEY ("siteId") REFERENCES "site"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "misc_upload" ADD CONSTRAINT "FK_5323ce07f1dd1b0483e55dc32b5" FOREIGN KEY ("instrumentId") REFERENCES "instrument"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "misc_upload" DROP CONSTRAINT "FK_5323ce07f1dd1b0483e55dc32b5"`);
+        await queryRunner.query(`ALTER TABLE "misc_upload" DROP CONSTRAINT "FK_23a6d85d68e4902c1769ef37c7e"`);
+        await queryRunner.query(`ALTER TABLE "instrument" DROP COLUMN "auxiliary"`);
+        await queryRunner.query(`DROP TABLE "misc_upload"`);
+        await queryRunner.query(`DROP TYPE "misc_upload_status_enum"`);
+    }
+
+}

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -46,7 +46,6 @@ export class UploadRoutes {
   readonly modelFileRepo: Repository<ModelFile>
   readonly regularFileRepo: Repository<RegularFile>
 
-  readonly miscInstruments = ['halo-doppler-lidar']
 
   postMetadata: RequestHandler = async (req: Request, res: Response, next) => {
     const body = req.body
@@ -368,7 +367,7 @@ export class UploadRoutes {
 
   isMiscUpload(instrument: Instrument | undefined) {
     if (!instrument) return false
-    return this.miscInstruments.includes(instrument.id)
+    return instrument.auxiliary
   }
 
 }

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -1,5 +1,5 @@
 import {Site} from '../entity/Site'
-import {InstrumentUpload, ModelUpload, Status, Upload} from '../entity/Upload'
+import {InstrumentUpload, MiscUpload, ModelUpload, Status, Upload} from '../entity/Upload'
 import {Connection, Repository} from 'typeorm'
 import {Request, RequestHandler, Response} from 'express'
 import {
@@ -27,6 +27,7 @@ export class UploadRoutes {
   constructor(conn: Connection) {
     this.conn = conn
     this.instrumentUploadRepo = this.conn.getRepository(InstrumentUpload)
+    this.miscUploadRepo = this.conn.getRepository(MiscUpload)
     this.modelUploadRepo = this.conn.getRepository(ModelUpload)
     this.instrumentRepo = this.conn.getRepository(Instrument)
     this.modelRepo = this.conn.getRepository(Model)
@@ -37,12 +38,15 @@ export class UploadRoutes {
 
   readonly conn: Connection
   readonly instrumentUploadRepo: Repository<InstrumentUpload>
+  readonly miscUploadRepo: Repository<MiscUpload>
   readonly modelUploadRepo: Repository<ModelUpload>
   readonly instrumentRepo: Repository<Instrument>
   readonly siteRepo: Repository<Site>
   readonly modelRepo: Repository<Model>
   readonly modelFileRepo: Repository<ModelFile>
   readonly regularFileRepo: Repository<RegularFile>
+
+  readonly miscInstruments = ['halo-doppler-lidar']
 
   postMetadata: RequestHandler = async (req: Request, res: Response, next) => {
     const body = req.body
@@ -69,6 +73,7 @@ export class UploadRoutes {
       instrument = await this.instrumentRepo.findOne(body.instrument)
       if (instrument == undefined) return next({status: 422, errors: 'Unknown instrument'})
       uploadRepo = this.instrumentUploadRepo
+      if (this.isMiscUpload(instrument)) uploadRepo = this.miscUploadRepo
       productRepo = this.regularFileRepo
     } else if (isModelSubmission) {
       model = await this.modelRepo.findOne(body.model)
@@ -119,13 +124,24 @@ export class UploadRoutes {
 
     let uploadedMetadata: InstrumentUpload | ModelUpload
     if (isInstrumentSubmission) {
-      uploadedMetadata = new InstrumentUpload(
-        body.checksum,
-        filename,
-        body.measurementDate,
-        site,
-        Status.CREATED,
-        instrument as Instrument)
+      if (this.isMiscUpload(instrument)) {
+        uploadedMetadata = new MiscUpload(
+          body.checksum,
+          filename,
+          body.measurementDate,
+          site,
+          Status.CREATED,
+          instrument as Instrument)
+
+      } else {
+        uploadedMetadata = new InstrumentUpload(
+          body.checksum,
+          filename,
+          body.measurementDate,
+          site,
+          Status.CREATED,
+          instrument as Instrument)
+      }
     } else {
       uploadedMetadata = new ModelUpload(
         body.checksum,
@@ -160,7 +176,8 @@ export class UploadRoutes {
     const partialUpload = req.body
     if (!partialUpload.uuid) return next({status: 422, errors: 'Request body is missing uuid'})
     try {
-      const upload = await this.findAnyUpload(repo => repo.findOne({uuid: partialUpload.uuid}))
+      const upload = await this.findAnyUpload((repo, model) =>
+        repo.findOne({uuid: partialUpload.uuid}, { relations: ['site', (model ? 'model' : 'instrument')] }))
       if (!upload) return next({status: 422, errors: 'No file matches the provided uuid'})
       await this.findRepoForUpload(upload).update({uuid: partialUpload.uuid}, partialUpload)
       res.sendStatus(200)
@@ -325,14 +342,15 @@ export class UploadRoutes {
     return next()
   }
 
-  findAnyUpload(searchFunc: (arg0: Repository<InstrumentUpload|ModelUpload>, arg1?: boolean) =>
-    Promise<InstrumentUpload|ModelUpload|undefined>):
-    Promise<InstrumentUpload|ModelUpload|undefined> {
+  findAnyUpload(searchFunc: (arg0: Repository<ModelUpload|InstrumentUpload|MiscUpload>, arg1?: boolean) =>
+    Promise<ModelUpload|InstrumentUpload|MiscUpload|undefined>):
+    Promise<ModelUpload|InstrumentUpload|MiscUpload|undefined> {
     return Promise.all([
       searchFunc(this.instrumentUploadRepo, false),
-      searchFunc(this.modelUploadRepo, true)
+      searchFunc(this.modelUploadRepo, true),
+      searchFunc(this.miscUploadRepo, false)
     ])
-      .then(([upload, modelUpload]) => upload || modelUpload)
+      .then(([upload, modelUpload, miscUpload]) => upload || modelUpload || miscUpload)
   }
 
   dateforsize: RequestHandler = async (req, res, next) => {
@@ -340,9 +358,17 @@ export class UploadRoutes {
     return dateforsize(isModel ? this.modelUploadRepo : this.instrumentUploadRepo, isModel ? 'model_upload' : 'instrument_upload', req, res, next)
   }
 
-  findRepoForUpload(upload: InstrumentUpload | ModelUpload) {
-    if ('instrument' in upload) return this.instrumentUploadRepo
+  findRepoForUpload(upload: InstrumentUpload | ModelUpload | MiscUpload) {
+    if ('instrument' in upload) {
+      if (this.isMiscUpload(upload.instrument)) return this.miscUploadRepo
+      return this.instrumentUploadRepo
+    }
     return this.modelUploadRepo
+  }
+
+  isMiscUpload(instrument: Instrument | undefined) {
+    if (!instrument) return false
+    return this.miscInstruments.includes(instrument.id)
   }
 
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,6 +98,7 @@ each having the properties:
 - `id`: Unique identifier of the instrument.
 - `humanReadableName`: Name of the instrument in a human readable format.
 - `type`: Instrument type. May be, for example, `radar`, `lidar`, or `mwr`.
+- `auxiliary`: Boolean. `true` if the instrument data is only stored and not used in operational processing. Otherwise `false`.
 
 Example query:
 
@@ -109,7 +110,8 @@ Response body:
   {
     "id": "mira",
     "humanReadableName": "METEK MIRA-35 cloud radar",
-    "type": "radar"
+    "type": "radar",
+    "auxiliary": false
   },
 ...
 ]

--- a/shared/res/instruments.json
+++ b/shared/res/instruments.json
@@ -22,7 +22,8 @@
   {
     "id": "halo-doppler-lidar",
     "type": "lidar",
-    "humanReadableName": "Halo Photonics Doppler lidar"
+    "humanReadableName": "Halo Photonics Doppler lidar",
+    "auxiliary": true
   },
   {
     "id": "hatpro",

--- a/shared/res/instruments.json
+++ b/shared/res/instruments.json
@@ -20,6 +20,11 @@
     "humanReadableName": "Vaisala CT25K ceilometer"
   },
   {
+    "id": "halo-doppler-lidar",
+    "type": "lidar",
+    "humanReadableName": "Halo Photonics Doppler lidar"
+  },
+  {
     "id": "hatpro",
     "type": "mwr",
     "humanReadableName": "RPG HATPRO microwave radiometer"


### PR DESCRIPTION
- Save halo-doppler-lidar uploads to a separate table
- The files will be saved to the upload bucket
- The files will not be visible in any upload-metadata listings