### PR TITLE
Fix visualization preview size in collection view

### DIFF
--- a/frontend/src/components/DataSearchResult.vue
+++ b/frontend/src/components/DataSearchResult.vue
@@ -129,6 +129,10 @@ section#fileTable
 #preview
   width: 100%
 
+.visualization
+  width: 100%
+  height: auto
+
 </style>
 
 

--- a/frontend/src/components/Visualization.vue
+++ b/frontend/src/components/Visualization.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-import {Component, Prop, Watch} from 'vue-property-decorator'
+import {Component, Prop} from 'vue-property-decorator'
 import Vue from 'vue'
 import {VisualizationItem} from '../../../backend/src/entity/VisualizationResponse'
 


### PR DESCRIPTION
Fix image size and page layout when selecting file in collection view, see for example https://cloudnet.fmi.fi/collection/a5753881-a284-497b-bc51-48205e84109a/files