### PR TITLE
Delete route

### DIFF
--- a/backend/fixtures/3-product_variable.json
+++ b/backend/fixtures/3-product_variable.json
@@ -22,5 +22,41 @@
     "humanReadableName": "Classification detection status",
     "product": "classification",
     "order": "1"
+  },
+  {
+    "id": "radar-v",
+    "humanReadableName": "Radar velocity",
+    "product": "radar",
+    "order": "2"
+  },
+  {
+    "id": "radar-ldr",
+    "humanReadableName": "Radar LDR",
+    "product": "radar",
+    "order": "3"
+  },
+  {
+    "id": "categorize-v",
+    "humanReadableName": "Categorize velocity",
+    "product": "categorize",
+    "order": "2"
+  },
+  {
+    "id": "categorize-ldr",
+    "humanReadableName": "Categorize LDR",
+    "product": "categorize",
+    "order": "3"
+  },
+  {
+    "id": "classification-v",
+    "humanReadableName": "Classification velocity",
+    "product": "classification",
+    "order": "2"
+  },
+  {
+    "id": "classification-ldr",
+    "humanReadableName": "Classification LDR",
+    "product": "classification",
+    "order": "3"
   }
 ]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "dataportal",
-   "version": "2.33.0",
+   "version": "2.33.1",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
    "name": "dataportal",
-   "version": "2.33.0",
+   "version": "2.33.1",
    "description": "Actris cloud remote sensing data portal",
    "main": "build/server.js",
    "directories": {

--- a/backend/run-test
+++ b/backend/run-test
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker exec -t dev-toolkit_dataportal-backend-test_1 "$@"
+docker exec -t dev-toolkit-dataportal-backend-test-1 "$@"

--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -108,7 +108,7 @@ export class Middleware {
     }
     if (query.updatedAtTo) query.updatedAtTo = new Date(query.updatedAtTo)
     if (query.updatedAtFrom) query.updatedAtFrom = new Date(query.updatedAtFrom)
-    query.s3path = (query.s3path || '').toLowerCase() == 'true' ? true : false
+    query.s3path = (query.s3path || '').toLowerCase() == 'true'
     next()
   }
 

--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -144,6 +144,17 @@ export class Middleware {
       .catch(next)
   }
 
+  checkDeleteParams: RequestHandler = async (req, _res, next) => {
+    const query: any = req.query
+    const key = 'deleteHigherProducts'
+    if (!query[key]) next({status: 404, errors: [`Missing mandatory parameter: ${key}`]})
+    const value = query[key].toLowerCase()
+    if (value === 'true') query[key] = true
+    else if (value === 'false') query[key] = false
+    else next({status: 400, errors: [`Invalid value for parameter ${key}: ${value}`]})
+    next()
+  }
+
   private throw404Error = (param: string, req: any) => {
     throw { status: 404, errors: [`One or more of the specified ${param}s were not found`], params: req.query }
   }

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -200,7 +200,7 @@ export class FileRoutes {
   deleteFile: RequestHandler = async (req: Request, res: Response, next) => {
     const uuid = req.params.uuid
     const query: any = req.query
-    const ignoreHigherProducts = 'ignoreHigherProducts' in query && query.ignoreHigherProducts.toLowerCase() === 'true'
+    const deleteHigherProducts = query.deleteHigherProducts
     try {
       const existingFile = await this.findAnyFile((repo) => repo.findOne(uuid, {relations: ['product', 'site']}))
       if (!existingFile) return next({status: 422, errors: ['No file matches the provided uuid']})
@@ -217,7 +217,7 @@ export class FileRoutes {
         measurementDate: existingFile.measurementDate,
         product: In(higherLevelProductNames)
       }})
-      if (!ignoreHigherProducts && products.length > 0) {
+      if (deleteHigherProducts && products.length > 0) {
         const onlyVolatileProducts = products.every(product => product.volatile)
         if (!onlyVolatileProducts) return next({status: 422, errors: ['Forbidden to delete due to higher level stable files']})
         for (const product of products) {

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -217,14 +217,9 @@ export class FileRoutes {
         measurementDate: existingFile.measurementDate,
         product: In(higherLevelProductNames)
       }})
-      if (ignoreHigherProducts || products.length == 0) {
-        await this.deleteFileAndVisualizations(fileRepo, visuRepo, uuid)
-        return res.sendStatus(200)
-      }
-      const onlyVolatileProducts = products.every(product => product.volatile)
-      if (!onlyVolatileProducts) {
-        return next({status: 422, errors: ['Forbidden to delete due to higher level stable files']})
-      } else {
+      if (!ignoreHigherProducts && products.length > 0) {
+        const onlyVolatileProducts = products.every(product => product.volatile)
+        if (!onlyVolatileProducts) return next({status: 422, errors: ['Forbidden to delete due to higher level stable files']})
         for (const product of products) {
           await this.deleteFileAndVisualizations(this.fileRepo, this.visualizationRepo, product.uuid)
         }

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -1,6 +1,6 @@
 import {Request, RequestHandler, Response} from 'express'
 import {Collection} from '../entity/Collection'
-import {Connection, EntityManager, Repository, SelectQueryBuilder} from 'typeorm'
+import {Connection, EntityManager, Repository, SelectQueryBuilder, In} from 'typeorm'
 import {isFile, RegularFile} from '../entity/File'
 import {
   checkFileExists, convertToReducedResponse,
@@ -16,6 +16,10 @@ import {Model} from '../entity/Model'
 import {basename} from 'path'
 import {ModelFile} from '../entity/File'
 import {SearchFileResponse} from '../entity/SearchFileResponse'
+import {Visualization} from '../entity/Visualization'
+import {ModelVisualization} from '../entity/ModelVisualization'
+import {Product} from '../entity/Product'
+
 
 export class FileRoutes {
 
@@ -25,6 +29,9 @@ export class FileRoutes {
     this.fileRepo = conn.getRepository<RegularFile>('regular_file')
     this.modelFileRepo = conn.getRepository<ModelFile>('model_file')
     this.searchFileRepo = conn.getRepository<SearchFile>('search_file')
+    this.visualizationRepo = conn.getRepository<Visualization>('visualization')
+    this.modelVisualizationRepo = conn.getRepository<ModelVisualization>('model_visualization')
+    this.productRepo = conn.getRepository<Product>('product')
   }
 
   readonly conn: Connection
@@ -32,6 +39,9 @@ export class FileRoutes {
   readonly fileRepo: Repository<RegularFile>
   readonly modelFileRepo: Repository<ModelFile>
   readonly searchFileRepo: Repository<SearchFile>
+  readonly visualizationRepo: Repository<Visualization>
+  readonly modelVisualizationRepo: Repository<ModelVisualization>
+  readonly productRepo: Repository<Product>
 
   file: RequestHandler = async (req: Request, res: Response, next) => {
 
@@ -187,6 +197,45 @@ export class FileRoutes {
     }
   }
 
+  deleteFile: RequestHandler = async (req: Request, res: Response, next) => {
+    const uuid = req.params.uuid
+    const query: any = req.query
+    const ignoreHigherProducts = 'ignoreHigherProducts' in query && query.ignoreHigherProducts.toLowerCase() === 'true'
+    try {
+      const existingFile = await this.findAnyFile((repo) => repo.findOne(uuid, {relations: ['product', 'site']}))
+      if (!existingFile) return next({status: 422, errors: ['No file matches the provided uuid']})
+      if (!existingFile.volatile) return next({status: 422, errors: ['Forbidden to delete a stable file']})
+      let fileRepo: Repository<RegularFile|ModelFile> = this.fileRepo
+      let visuRepo: Repository<Visualization|ModelVisualization> = this.visualizationRepo
+      if (existingFile.product.id == 'model') {
+        fileRepo = this.modelFileRepo
+        visuRepo = this.modelVisualizationRepo
+      }
+      const higherLevelProductNames = await this.getHigherLevelProducts(existingFile.product)
+      let products = await this.fileRepo.find({where: {
+        site: existingFile.site,
+        measurementDate: existingFile.measurementDate,
+        product: In(higherLevelProductNames)
+        }})
+      if (ignoreHigherProducts || products.length == 0) {
+        await FileRoutes.deleteFileAndVisualizations(fileRepo, visuRepo, uuid)
+        return res.sendStatus(200)
+      }
+      const onlyVolatileProducts = products.every(product => product.volatile)
+      if (!onlyVolatileProducts) {
+        return next({status: 422, errors: ['Forbidden to delete due to higher level stable files']})
+      } else {
+        for (const product of products) {
+          await FileRoutes.deleteFileAndVisualizations(this.fileRepo, this.visualizationRepo, product.uuid)
+        }
+      }
+      await FileRoutes.deleteFileAndVisualizations(fileRepo, visuRepo, uuid)
+      res.sendStatus(200)
+    } catch (e) {
+      return next({status: 500, errors: e})
+    }
+  }
+
   allfiles: RequestHandler = async (req: Request, res: Response, next) =>
     this.fileRepo.find({ relations: ['site', 'product'] })
       .then(result => res.send(sortByMeasurementDateAsc(result).map(augmentFile(false))))
@@ -302,6 +351,38 @@ export class FileRoutes {
     const isModel = 'model' in req.query
     return dateforsize(isModel ? this.modelFileRepo : this.fileRepo, isModel ? 'model_file' : 'regular_file', req, res, next)
   }
+
+  private static async deleteFileAndVisualizations(fileRepo: Repository<RegularFile|ModelFile>,
+                                                   visualizationRepo: Repository<Visualization|ModelVisualization>,
+                                                   uuid: string) {
+    await visualizationRepo.createQueryBuilder()
+        .delete()
+        .where({ sourceFile: uuid })
+        .execute()
+    await fileRepo.createQueryBuilder()
+        .delete()
+        .where({ uuid: uuid })
+        .execute()
+  }
+
+  private async getHigherLevelProducts(product: Product):Promise<string[]> {
+    // Returns Cloudnet products that are of higher level than the given product.
+    let uniqueLevels = await this.productRepo
+        .createQueryBuilder()
+        .select('DISTINCT level')
+        .orderBy('level')
+        .getRawMany()
+    uniqueLevels = uniqueLevels.map(level => level.level)
+    const index = uniqueLevels.indexOf(product.level)
+    const levels =  uniqueLevels.slice(index + 1)
+    let products = await this.productRepo
+        .createQueryBuilder()
+        .where({level: In(levels)})
+        .select('id')
+        .getRawMany()
+    return products.map(prod => prod.id)
+  }
+
 }
 
 function addCommonFilters<T>(qb: SelectQueryBuilder<T>, query: any) {

--- a/backend/src/routes/file.ts
+++ b/backend/src/routes/file.ts
@@ -216,7 +216,7 @@ export class FileRoutes {
         site: existingFile.site,
         measurementDate: existingFile.measurementDate,
         product: In(higherLevelProductNames)
-        }})
+      }})
       if (ignoreHigherProducts || products.length == 0) {
         await FileRoutes.deleteFileAndVisualizations(fileRepo, visuRepo, uuid)
         return res.sendStatus(200)
@@ -353,33 +353,33 @@ export class FileRoutes {
   }
 
   private static async deleteFileAndVisualizations(fileRepo: Repository<RegularFile|ModelFile>,
-                                                   visualizationRepo: Repository<Visualization|ModelVisualization>,
-                                                   uuid: string) {
+    visualizationRepo: Repository<Visualization|ModelVisualization>,
+    uuid: string) {
     await visualizationRepo.createQueryBuilder()
-        .delete()
-        .where({ sourceFile: uuid })
-        .execute()
+      .delete()
+      .where({ sourceFile: uuid })
+      .execute()
     await fileRepo.createQueryBuilder()
-        .delete()
-        .where({ uuid: uuid })
-        .execute()
+      .delete()
+      .where({ uuid: uuid })
+      .execute()
   }
 
   private async getHigherLevelProducts(product: Product):Promise<string[]> {
     // Returns Cloudnet products that are of higher level than the given product.
     let uniqueLevels = await this.productRepo
-        .createQueryBuilder()
-        .select('DISTINCT level')
-        .orderBy('level')
-        .getRawMany()
+      .createQueryBuilder()
+      .select('DISTINCT level')
+      .orderBy('level')
+      .getRawMany()
     uniqueLevels = uniqueLevels.map(level => level.level)
     const index = uniqueLevels.indexOf(product.level)
     const levels =  uniqueLevels.slice(index + 1)
     let products = await this.productRepo
-        .createQueryBuilder()
-        .where({level: In(levels)})
-        .select('id')
-        .getRawMany()
+      .createQueryBuilder()
+      .where({level: In(levels)})
+      .select('id')
+      .getRawMany()
     return products.map(prod => prod.id)
   }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -179,7 +179,7 @@ import env from './lib/env'
   app.get('/file-dateforsize', fileRoutes.dateforsize)
   app.put('/quality/:uuid', express.json(), qualityRoutes.putQualityReport)
   app.get('/api/download/stats', authMiddleware, dlRoutes.stats)
-  app.delete('/files/:uuid', fileRoutes.deleteFile)
+  app.delete('/files/:uuid', middleware.checkDeleteParams, fileRoutes.deleteFile)
 
   app.use(errorHandler)
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -179,6 +179,7 @@ import env from './lib/env'
   app.get('/file-dateforsize', fileRoutes.dateforsize)
   app.put('/quality/:uuid', express.json(), qualityRoutes.putQualityReport)
   app.get('/api/download/stats', authMiddleware, dlRoutes.stats)
+  app.delete('/files/:uuid', fileRoutes.deleteFile)
 
   app.use(errorHandler)
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -64,7 +64,6 @@ import env from './lib/env'
     next(err)
   }
 
-  // In production, authentication is handled by nginx.
   let authMiddleware = basicAuth({
     users: { 'admin': env.STATS_PASSWORD },
     challenge: true,
@@ -179,7 +178,7 @@ import env from './lib/env'
   app.get('/file-dateforsize', fileRoutes.dateforsize)
   app.put('/quality/:uuid', express.json(), qualityRoutes.putQualityReport)
   app.get('/api/download/stats', authMiddleware, dlRoutes.stats)
-  app.delete('/files/:uuid', middleware.checkDeleteParams, fileRoutes.deleteFile)
+  app.delete('/files/:uuid', authMiddleware, middleware.checkDeleteParams, fileRoutes.deleteFile)
 
   app.use(errorHandler)
 

--- a/backend/tests/integration/sequential/file.test.ts
+++ b/backend/tests/integration/sequential/file.test.ts
@@ -467,11 +467,11 @@ describe('DELETE /files/', () => {
 
   async function put_categorize(volatile: boolean = true) {
     const categorizeFile  = {...volatileFile, ...{
-        product: 'categorize',
-        uuid: '27325787-6cbe-4e2c-a749-4bc9191b55a6',
-        checksum: '46ceff4e71f5acc8f8b1d20cccb9995d4bf353093b8e9a817ee5943f6d5d554c',
-        s3key: '20181115_mace-head_categorize.nc',
-        volatile: volatile}
+      product: 'categorize',
+      uuid: '27325787-6cbe-4e2c-a749-4bc9191b55a6',
+      checksum: '46ceff4e71f5acc8f8b1d20cccb9995d4bf353093b8e9a817ee5943f6d5d554c',
+      s3key: '20181115_mace-head_categorize.nc',
+      volatile: volatile}
     }
     const bucketFix = volatile ? '-volatile' : ''
     await axios.put(`${storageServiceUrl}cloudnet-product${bucketFix}/${categorizeFile.s3key}`, 'content')
@@ -482,7 +482,7 @@ describe('DELETE /files/', () => {
   async function put_image(id: string, file: any) {
     const payload = {
       sourceFileId: file.uuid,
-      variableId: id.replace(/\.[^/.]+$/, "")
+      variableId: id.replace(/\.[^/.]+$/, '')
     }
     await axios.put(`${storageServiceUrl}cloudnet-img/${id}`, 'content')
     await axios.put(`${privUrl}${id}`, payload)

--- a/backend/tests/integration/sequential/file.test.ts
+++ b/backend/tests/integration/sequential/file.test.ts
@@ -60,7 +60,7 @@ async function deleteFile(uuid: string, deleteHigherProducts: any = null) {
   const url = `${backendPrivateUrl}files/${uuid}`
   let params = {}
   if (!(deleteHigherProducts === null)) params = { deleteHigherProducts: deleteHigherProducts }
-  return await axios.delete(url, { params: params })
+  return await axios.delete(url, { params: params, auth: { username: 'admin', password: 'admin' } })
 }
 
 describe('PUT /files/:s3key', () => {

--- a/shared/res/products-with-variables.json
+++ b/shared/res/products-with-variables.json
@@ -35,6 +35,16 @@
         "id": "classification-detection_status",
         "humanReadableName": "Classification detection status",
         "order": "1"
+      },
+      {
+        "id": "classification-v",
+        "humanReadableName": "Classification velocity",
+        "order": "2"
+      },
+      {
+        "id": "classification-ldr",
+        "humanReadableName": "Classification LDR",
+        "order": "3"
       }
     ]
   },
@@ -74,6 +84,16 @@
         "id": "test1",
         "humanReadableName": "Auringonpaisteen määrä",
         "order": "1"
+      },
+      {
+        "id": "categorize-v",
+        "humanReadableName": "Categorize velocity",
+        "order": "2"
+      },
+      {
+        "id": "categorize-ldr",
+        "humanReadableName": "Categorize LDR",
+        "order": "3"
       }
     ]
   },
@@ -110,6 +130,17 @@
     "humanReadableName": "Radar",
     "level": "1b",
     "experimental": false,
-    "variables": []
+    "variables": [
+      {
+        "id": "radar-v",
+        "humanReadableName": "Radar velocity",
+        "order": "2"
+      },
+      {
+        "id": "radar-ldr",
+        "humanReadableName": "Radar LDR",
+        "order": "3"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds `DELETE /files/:uuid?deleteHigherProducts=<true|false>` route with the following functionality:
- Works with regular products and model files, but not e.g. with submitted instrument files.
- Deletes only `volatile` files.
- Also deletes corresponding images.
- Deletes the requested file **and all higher level files** if those exist and are all volatile. Otherwise returns `422`.

!!! AUTHENTICATION NEEDS TO BE CHECKED BEFORE DEPLOY !!!