### PR TITLE
Improve delete route

### DIFF
--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -144,17 +144,6 @@ export class Middleware {
       .catch(next)
   }
 
-  checkDeleteParams: RequestHandler = async (req, _res, next) => {
-    const query: any = req.query
-    const key = 'deleteHigherProducts'
-    if (!query[key]) next({status: 404, errors: [`Missing mandatory parameter: ${key}`]})
-    const value = query[key].toLowerCase()
-    if (value === 'true') query[key] = true
-    else if (value === 'false') query[key] = false
-    else next({status: 400, errors: [`Invalid value for parameter ${key}: ${value}`]})
-    next()
-  }
-
   private throw404Error = (param: string, req: any) => {
     throw { status: 404, errors: [`One or more of the specified ${param}s were not found`], params: req.query }
   }
@@ -166,6 +155,19 @@ export class Middleware {
       .then(res => {
         if (res.length != req.query[param].length) this.throw404Error(param, req)
       })
+  }
+
+  checkDeleteParams: RequestHandler = async (req, _res, next) => {
+    const query: any = req.query
+    const keys = ['deleteHigherProducts', 'dryRun']
+    for (const key of keys) {
+      if (!query[key]) next({status: 404, errors: [`Missing mandatory parameter: ${key}`]})
+      const value = query[key].toLowerCase()
+      if (value === 'true') query[key] = true
+      else if (value === 'false') query[key] = false
+      else next({status: 400, errors: [`Invalid value for parameter ${key}: ${value}`]})
+    }
+    next()
   }
 
   private checkSite = async (req: any) => {


### PR DESCRIPTION
- `dryRun` parameter for testing the delete route without actually deleting anything.
- Returns filenames (s3 keys) of the deleted products and images.