### PR TITLE
Several l1b

### DIFF
--- a/backend/fixtures/2-instrument.json
+++ b/backend/fixtures/2-instrument.json
@@ -2,41 +2,49 @@
   {
     "id": "mira",
     "type": "radar",
+    "shortName": "MIRA",
     "humanReadableName": "METEK MIRA-35 cloud radar"
   },
   {
     "id": "rpg-fmcw-94",
     "type": "radar",
+    "shortName": "RPG FMCW-94",
     "humanReadableName": "RPG FMCW-94 cloud radar"
   },
   {
     "id": "ct25k",
     "type": "lidar",
+    "shortName": "CT25K",
     "humanReadableName": "Vaisala CT25K ceilometer"
   },
   {
     "id": "cl31",
     "type": "lidar",
+    "shortName": "CL31",
     "humanReadableName": "Vaisala CL31 ceilometer"
   },
   {
     "id": "cl51",
     "type": "lidar",
+    "shortName": "CL51",
     "humanReadableName": "Vaisala CL51 ceilometer"
   },
   {
     "id": "chm15k",
     "type": "lidar",
+    "shortName": "CHM15K",
     "humanReadableName": "Lufft CHM15k ceilometer"
   },
   {
     "id": "hatpro",
     "type": "mwr",
+    "shortName": "HATPRO",
     "humanReadableName": "RPG HATPRO microwave radiometer"
   },
   {
     "id": "halo-doppler-lidar",
     "type": "lidar",
+    "shortName": "Halo Doppler Lidar",
     "humanReadableName": "Halo Photonics Doppler lidar",
     "allowedTags": ["co", "cross"]
   }

--- a/backend/fixtures/2-regular_file.json
+++ b/backend/fixtures/2-regular_file.json
@@ -14,7 +14,8 @@
     "site": "mace-head",
     "version": "123",
     "errorLevel": null,
-    "software": [{ "id": 1 }]
+    "software": [{ "id": 1 }],
+    "instrument": "mira"
   },
   {
     "uuid": "bde7a35f-03aa-4bff-acfb-b4974ea9f217",
@@ -48,7 +49,8 @@
     "site": "hyytiala",
     "version": "123",
     "errorLevel": null,
-    "software": [{ "id": 1 }]
+    "software": [{ "id": 1 }],
+    "instrument": "rpg-fmcw-94"
   },
   {
     "uuid": "22b32746-faf0-4057-9076-ed2e698dcc34",
@@ -248,7 +250,8 @@
     "version": "123",
     "quality": "qc",
     "errorLevel": "error",
-    "software": [{ "id": 1 }]
+    "software": [{ "id": 1 }],
+    "instrument": "mira"
   },
   {
     "uuid": "b6de8cf4-8825-47b0-aaa9-4fd413bbb0d7",
@@ -266,7 +269,8 @@
     "version": "123",
     "errorLevel": null,
     "instrumentPid": "https://hdl.handle.net/123/bucharest_lidar",
-    "software": [{ "id": 1 }]
+    "software": [{ "id": 1 }],
+    "instrument": "chm15k"
   },
   {
     "uuid": "f036da43-c19c-4832-99f9-6cc88f3255c5",
@@ -284,6 +288,7 @@
     "version": "123",
     "errorLevel": null,
     "instrumentPid": "https://hdl.handle.net/123/bucharest_radar",
-    "software": [{ "id": 1 }]
+    "software": [{ "id": 1 }],
+    "instrument": "rpg-fmcw-94"
   }
 ]

--- a/backend/src/entity/File.ts
+++ b/backend/src/entity/File.ts
@@ -20,6 +20,7 @@ import { Model } from "./Model";
 import { ModelVisualization } from "./ModelVisualization";
 import { ErrorLevel } from "./QualityReport";
 import { Software } from "./Software";
+import { Instrument } from "./Instrument";
 
 export enum Quality {
   NRT = "nrt",
@@ -102,6 +103,7 @@ export abstract class File {
   }
 }
 
+@Index(["instrument"])
 @Entity()
 export class RegularFile extends File {
   @Column("uuid", { array: true, nullable: true })
@@ -112,6 +114,9 @@ export class RegularFile extends File {
 
   @Column({ nullable: true })
   instrumentPid!: string;
+
+  @ManyToOne((_) => Instrument, (instrument) => instrument.files, { nullable: true })
+  instrument!: Instrument | null;
 }
 
 @Entity()

--- a/backend/src/entity/Instrument.ts
+++ b/backend/src/entity/Instrument.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, OneToMany, PrimaryColumn } from "typeorm";
 import { InstrumentUpload } from "./Upload";
+import { RegularFile } from "./File";
 
 export enum InstrumentType {
   RADAR = "radar",
@@ -19,9 +20,15 @@ export class Instrument {
   @Column()
   humanReadableName!: string;
 
+  @Column({ default: "" })
+  shortName!: string;
+
   @Column({ type: "text", array: true, default: [], nullable: false })
   allowedTags!: Array<string>;
 
   @OneToMany((_) => InstrumentUpload, (upload) => upload.instrument)
   uploads!: InstrumentUpload[];
+
+  @OneToMany((_) => RegularFile, (regularFile) => regularFile.instrument)
+  files!: RegularFile[];
 }

--- a/backend/src/entity/SearchFile.ts
+++ b/backend/src/entity/SearchFile.ts
@@ -1,11 +1,11 @@
-import { Column, Entity, ManyToOne, PrimaryColumn, Unique } from "typeorm";
+import { Column, Entity, ManyToOne, PrimaryColumn } from "typeorm";
 import { Site } from "./Site";
 import { Product } from "./Product";
-import { File } from "./File";
+import { ModelFile, RegularFile, File } from "./File";
 import { ErrorLevel } from "./QualityReport";
+import { Instrument } from "./Instrument";
 
 @Entity()
-@Unique(["measurementDate", "site", "product"])
 export class SearchFile {
   @PrimaryColumn("uuid")
   uuid!: string;
@@ -35,7 +35,13 @@ export class SearchFile {
   })
   errorLevel!: ErrorLevel | null;
 
-  constructor(file: File) {
+  @ManyToOne((_) => Instrument, (instrument) => instrument.files, { nullable: true })
+  instrument!: Instrument | null;
+
+  @Column({ nullable: true })
+  instrumentPid!: string;
+
+  constructor(file: RegularFile | ModelFile) {
     // A typeorm hack, see https://github.com/typeorm/typeorm/issues/3903
     if (typeof file == "undefined") return;
 
@@ -47,5 +53,11 @@ export class SearchFile {
     this.volatile = file.volatile;
     this.legacy = file.legacy || false;
     this.errorLevel = file.errorLevel;
+    if ("instrument" in file) {
+      this.instrument = file.instrument;
+    }
+    if ("instrumentPid" in file) {
+      this.instrumentPid = file.instrumentPid;
+    }
   }
 }

--- a/backend/src/entity/SearchFileResponse.ts
+++ b/backend/src/entity/SearchFileResponse.ts
@@ -13,6 +13,8 @@ export class SearchFileResponse {
   legacy: boolean;
   experimental: boolean;
   errorLevel: ErrorLevel | null;
+  instrument: string | null;
+  instrumentId: string | null;
 
   constructor(file: SearchFile) {
     this.uuid = file.uuid;
@@ -26,5 +28,7 @@ export class SearchFileResponse {
     this.legacy = file.legacy;
     this.experimental = file.product.experimental;
     this.errorLevel = file.errorLevel;
+    this.instrument = file.instrument ? file.instrument.shortName || file.instrument.humanReadableName : null;
+    this.instrumentId = file.instrument ? file.instrument.id : null;
   }
 }

--- a/backend/src/lib/middleware.ts
+++ b/backend/src/lib/middleware.ts
@@ -70,6 +70,7 @@ export class Middleware {
       "updatedAtTo",
       "s3path",
       "status",
+      "instrumentPid",
       "instrument",
     ];
 
@@ -128,6 +129,8 @@ export class Middleware {
     query.model = toArray(query.model);
     query.volatile = toArray(query.volatile);
     query.filename = toArray(query.filename);
+    query.instrument = toArray(query.instrument);
+    query.instrumentPid = toArray(query.instrumentPid);
     query.legacy = setLegacy();
     if (query.date) {
       query.dateFrom = query.date;

--- a/backend/src/migration/1693400699080-AddInstrumentId.ts
+++ b/backend/src/migration/1693400699080-AddInstrumentId.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddInstrumentId1693400699080 implements MigrationInterface {
+  name = "AddInstrumentId1693400699080";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "search_file" DROP CONSTRAINT "UQ_04b805110f90917f6f029ed506a"`);
+    await queryRunner.query(`ALTER TABLE "regular_file" ADD "instrumentId" character varying`);
+    await queryRunner.query(`ALTER TABLE "search_file" ADD "instrumentPid" character varying`);
+    await queryRunner.query(`ALTER TABLE "search_file" ADD "instrumentId" character varying`);
+    await queryRunner.query(
+      `ALTER TABLE "regular_file" ADD CONSTRAINT "FK_73c0ef719842a790c4ddfd9aad0" FOREIGN KEY ("instrumentId") REFERENCES "instrument"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "search_file" ADD CONSTRAINT "FK_d1671c45b493f5c5451cc920098" FOREIGN KEY ("instrumentId") REFERENCES "instrument"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "search_file" DROP CONSTRAINT "FK_d1671c45b493f5c5451cc920098"`);
+    await queryRunner.query(`ALTER TABLE "regular_file" DROP CONSTRAINT "FK_73c0ef719842a790c4ddfd9aad0"`);
+    await queryRunner.query(`ALTER TABLE "search_file" DROP COLUMN "instrumentId"`);
+    await queryRunner.query(`ALTER TABLE "search_file" DROP COLUMN "instrumentPid"`);
+    await queryRunner.query(`ALTER TABLE "regular_file" DROP COLUMN "instrumentId"`);
+    await queryRunner.query(
+      `ALTER TABLE "search_file" ADD CONSTRAINT "UQ_04b805110f90917f6f029ed506a" UNIQUE ("measurementDate", "siteId", "productId")`,
+    );
+  }
+}

--- a/backend/src/migration/1693482497400-AddShortNameToInstrument.ts
+++ b/backend/src/migration/1693482497400-AddShortNameToInstrument.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddShortNameToInstrument1693482497400 implements MigrationInterface {
+  name = "AddShortNameToInstrument1693482497400";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "instrument" ADD "shortName" character varying NOT NULL DEFAULT ''`);
+    await queryRunner.query(`CREATE INDEX "IDX_73c0ef719842a790c4ddfd9aad" ON "regular_file" ("instrumentId") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_73c0ef719842a790c4ddfd9aad"`);
+    await queryRunner.query(`ALTER TABLE "instrument" DROP COLUMN "shortName"`);
+  }
+}

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -274,12 +274,13 @@ export class UploadRoutes {
       dateFrom: query.dateFrom || "1970-01-01",
       dateTo: query.dateTo || tomorrow(),
       instrument: model ? undefined : query.instrument,
+      instrumentPid: model ? undefined : query.instrumentPid,
       model: model ? query.model : undefined,
       updatedAtFrom: query.updatedAtFrom ? new Date(query.updatedAtFrom) : "1970-01-01T00:00:00.000Z",
       updatedAtTo: query.updatedAtTo ? new Date(query.updatedAtTo) : tomorrow(),
     };
 
-    const fieldsToArray = ["site", "status", "instrument", "model"];
+    const fieldsToArray = ["site", "status", "instrument", "model", "instrumentPid"];
     fieldsToArray.forEach((element) => (augmentedQuery[element] = toArray(augmentedQuery[element])));
 
     const qb = repo.createQueryBuilder("um");
@@ -295,6 +296,7 @@ export class UploadRoutes {
       .andWhere("site.id IN (:...site)", augmentedQuery)
       .andWhere("um.status IN (:...status)", augmentedQuery);
     if (query.instrument) qb.andWhere("instrument.id IN (:...instrument)", augmentedQuery);
+    if (query.instrumentPid) qb.andWhere("um.instrumentPid IN (:...instrumentPid)", augmentedQuery);
     if (query.model) qb.andWhere("model.id IN (:...model)", augmentedQuery);
 
     if (!onlyDistinctInstruments) qb.addOrderBy("size", "DESC");

--- a/backend/tests/integration/parallel/__snapshots__/file.test.ts.snap
+++ b/backend/tests/integration/parallel/__snapshots__/file.test.ts.snap
@@ -8,6 +8,12 @@ exports[`/api/files/:uuid request succeeds on instrument file 1`] = `
   "errorLevel": null,
   "filename": "20181115_mace-head_mira.nc",
   "format": "HDF5 (NetCDF4)",
+  "instrument": Object {
+    "allowedTags": Array [],
+    "humanReadableName": "METEK MIRA-35 cloud radar",
+    "id": "mira",
+    "type": "radar",
+  },
   "instrumentPid": null,
   "legacy": false,
   "measurementDate": "2018-11-15",

--- a/backend/tests/integration/parallel/__snapshots__/file.test.ts.snap
+++ b/backend/tests/integration/parallel/__snapshots__/file.test.ts.snap
@@ -8,8 +8,8 @@ exports[`/api/files/:uuid request succeeds on instrument file 1`] = `
   "errorLevel": null,
   "filename": "20181115_mace-head_mira.nc",
   "format": "HDF5 (NetCDF4)",
-  "instrument": Object {
-    "allowedTags": Array [],
+  "instrument": {
+    "allowedTags": [],
     "humanReadableName": "METEK MIRA-35 cloud radar",
     "id": "mira",
     "shortName": "MIRA",

--- a/backend/tests/integration/parallel/__snapshots__/file.test.ts.snap
+++ b/backend/tests/integration/parallel/__snapshots__/file.test.ts.snap
@@ -12,6 +12,7 @@ exports[`/api/files/:uuid request succeeds on instrument file 1`] = `
     "allowedTags": Array [],
     "humanReadableName": "METEK MIRA-35 cloud radar",
     "id": "mira",
+    "shortName": "MIRA",
     "type": "radar",
   },
   "instrumentPid": null,

--- a/backend/tests/integration/parallel/search.test.ts
+++ b/backend/tests/integration/parallel/search.test.ts
@@ -40,7 +40,7 @@ describe("/api/files", () => {
     );
   });
 
-  it("responds with an array of 3 objects when searching for mace-head", async () => {
+  it("responds with an array of 2 objects when searching for mace-head", async () => {
     const payload = { params: { site: "mace-head" } };
     const res = await axios.get(url, payload);
     expect(res).toHaveProperty("data");
@@ -48,7 +48,15 @@ describe("/api/files", () => {
     return expect(res.data.map((d: any) => d.site.id)).toEqual(["mace-head", "mace-head"]);
   });
 
-  it("responds with an array of 4 objects when searching for mace-head and hyytiala", async () => {
+  it("responds with an array of 2 objects when searching for mira", async () => {
+    const payload = { params: { instrument: "mira" } };
+    const res = await axios.get(url, payload);
+    expect(res).toHaveProperty("data");
+    expect(res.data).toHaveLength(2);
+    return expect(res.data.map((d: any) => d.instrument.id)).toEqual(["mira", "mira"]);
+  });
+
+  it("responds with an array of 3 objects when searching for mace-head and hyytiala", async () => {
     const payload = { params: { site: ["mace-head", "hyytiala"] } };
     const res = await axios.get(url, payload);
     expect(res).toHaveProperty("data");

--- a/backend/tests/integration/sequential/quality.test.ts
+++ b/backend/tests/integration/sequential/quality.test.ts
@@ -18,7 +18,7 @@ let testInfoRepo: Repository<TestInfo>;
 let qualityReportRepo: Repository<QualityReport>;
 let fileQualityRepo: Repository<FileQuality>;
 let regularFileRepo: Repository<RegularFile>;
-let modelFileRepo: Repository<SearchFile>;
+let modelFileRepo: Repository<ModelFile>;
 let searchFileRepo: Repository<SearchFile>;
 const privateUrl = `${backendPrivateUrl}quality/`;
 const publicUrl = `${backendPublicUrl}quality/`;

--- a/frontend/src/components/DataSearchResult.vue
+++ b/frontend/src/components/DataSearchResult.vue
@@ -252,7 +252,7 @@ section#fileTable
               <dd v-else class="notAvailable"></dd>
               <dt>Filename</dt>
               <dd>{{ previewResponse.filename }}</dd>
-              <template v-if="'instrument' in previewResponse">
+              <template v-if="'instrument' in previewResponse && previewResponse.instrument !== null">
                 <dt>Instrument</dt>
                 <dd>{{ previewResponse.instrument.shortName }}</dd>
               </template>

--- a/frontend/src/components/DataSearchResult.vue
+++ b/frontend/src/components/DataSearchResult.vue
@@ -258,7 +258,7 @@ section#fileTable
               </template>
               <template v-if="'model' in previewResponse">
                 <dt>Model</dt>
-                <dd>{{ previewResponse.model.id }}</dd>
+                <dd>{{ previewResponse.model.humanReadableName }}</dd>
               </template>
               <dt>Size</dt>
               <dd>{{ humanReadableSize(previewResponse.size) }}</dd>

--- a/frontend/src/components/DataSearchResult.vue
+++ b/frontend/src/components/DataSearchResult.vue
@@ -252,6 +252,14 @@ section#fileTable
               <dd v-else class="notAvailable"></dd>
               <dt>Filename</dt>
               <dd>{{ previewResponse.filename }}</dd>
+              <template v-if="'instrument' in previewResponse">
+                <dt>Instrument</dt>
+                <dd>{{ previewResponse.instrument.shortName }}</dd>
+              </template>
+              <template v-if="'model' in previewResponse">
+                <dt>Model</dt>
+                <dd>{{ previewResponse.model.id }}</dd>
+              </template>
               <dt>Size</dt>
               <dd>{{ humanReadableSize(previewResponse.size) }}</dd>
               <dt>Last modified</dt>

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -4,6 +4,7 @@ import type { SearchFileResponse } from "@shared/entity/SearchFileResponse";
 import type { Product } from "@shared/entity/Product";
 import type { CollectionFileResponse } from "@shared/entity/CollectionFileResponse";
 import type { Site, SiteType } from "@shared/entity/Site";
+import type { Instrument } from "@shared/entity/Instrument";
 
 import categorizeIcon from "@/assets/icons/categorize.png";
 import categorizeVoodooIcon from "@/assets/icons/categorize-voodoo.png";
@@ -159,7 +160,6 @@ import testFailIcon from "@/assets/icons/test-fail.svg";
 import testWarningIcon from "@/assets/icons/test-warning.svg";
 import testInfoIcon from "@/assets/icons/test-info.svg";
 import testPassIcon from "@/assets/icons/test-pass.svg";
-import { Instrument } from "@shared/entity/Instrument";
 
 export function getQcIcon(errorLevel: string) {
   if (errorLevel === "error") {

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -73,6 +73,8 @@ export const getProductIcon = (product: Product | string) => {
   return productIcons[id] || unknownIcon;
 };
 
+export const getInstrumentIcon = (instrument: Instrument) => getProductIcon(instrument.type);
+
 export const humanReadableSize = (size: number) => {
   if (size == 0) return "0 B";
   const i = Math.floor(Math.log(size) / Math.log(1024));
@@ -157,6 +159,7 @@ import testFailIcon from "@/assets/icons/test-fail.svg";
 import testWarningIcon from "@/assets/icons/test-warning.svg";
 import testInfoIcon from "@/assets/icons/test-info.svg";
 import testPassIcon from "@/assets/icons/test-pass.svg";
+import { Instrument } from "@shared/entity/Instrument";
 
 export function getQcIcon(errorLevel: string) {
   if (errorLevel === "error") {

--- a/frontend/src/views/SearchView.vue
+++ b/frontend/src/views/SearchView.vue
@@ -389,6 +389,7 @@ div.checkbox
         :options="allInstruments"
         id="instrumentSelect"
         :multiple="true"
+        :getIcon="getInstrumentIcon"
       />
 
       <custom-multiselect
@@ -455,6 +456,7 @@ import {
   isSameDay,
   isValidDate,
   getMarkerIcon,
+  getInstrumentIcon,
 } from "@/lib";
 import VizSearchResult from "@/components/VizSearchResult.vue";
 import type { Product } from "@shared/entity/Product";
@@ -593,7 +595,7 @@ async function initView() {
     extraSiteIds.value = extraSites.value.map((site) => site.id);
     allProducts.value = products.data.filter(discardExperimentalProducts).sort(alphabeticalSort);
     allInstruments.value = instruments.data.sort(alphabeticalSort).map((i: Instrument) => ({
-      id: i.id,
+      ...i,
       humanReadableName: i.shortName || i.humanReadableName,
     }));
     normalProducts.value = products.data.filter((prod: Product) => !prod.experimental).sort(alphabeticalSort);

--- a/frontend/src/views/SearchView.vue
+++ b/frontend/src/views/SearchView.vue
@@ -825,7 +825,12 @@ const selectableVariables = computed(() => {
 });
 
 const noSelectionsMade = computed(() => {
-  return !(selectedProductIds.value.length || selectedSiteIds.value.length || selectedVariableIds.value.length);
+  return !(
+    selectedProductIds.value.length ||
+    selectedSiteIds.value.length ||
+    selectedVariableIds.value.length ||
+    selectedInstrumentIds.value.length
+  );
 });
 
 watch(

--- a/frontend/src/views/SiteView.vue
+++ b/frontend/src/views/SiteView.vue
@@ -221,7 +221,7 @@ import type { SearchFileResponse } from "@shared/entity/SearchFileResponse";
 import MyMap from "@/components/SuperMap.vue";
 import ProductAvailabilityVisualization from "@/components/ProductAvailabilityVisualization.vue";
 import ProductAvailabilityVisualizationSingle from "@/components/ProductAvailabilityVisualizationSingle.vue";
-import { getProductIcon, formatCoordinates, fetchInstrumentName, actrisNfUrl } from "@/lib";
+import { getProductIcon, formatCoordinates, fetchInstrumentName, actrisNfUrl, getInstrumentIcon } from "@/lib";
 import { parseDataStatus, type DataStatus } from "@/lib/DataStatusParser";
 import CustomMultiselect from "@/components/MultiSelect.vue";
 import type { ReducedMetadataResponse } from "@shared/entity/ReducedMetadataResponse";
@@ -370,13 +370,13 @@ async function handleInstrument(response: ReducedMetadataResponse): Promise<Inst
         console.error("Failed to load instrument information", error);
         return response.instrument.humanReadableName;
       }),
-      icon: getProductIcon(response.instrument.type),
+      icon: getInstrumentIcon(response.instrument),
     };
   } else {
     return {
       pid: null,
       name: `Unidentified ${response.instrument.humanReadableName}`,
-      icon: getProductIcon(response.instrument.type),
+      icon: getInstrumentIcon(response.instrument),
     };
   }
 }

--- a/frontend/tests/SearchView.test.ts
+++ b/frontend/tests/SearchView.test.ts
@@ -48,20 +48,22 @@ describe("SearchView.vue", () => {
     filesSortedByDate = resources["allfiles"].sort(
       (a: any, b: any) => new Date(a.measurementDate).getTime() - new Date(b.measurementDate).getTime(),
     );
-    const defaultAxiosMock = (url: string): AxiosPromise => {
-      if (url.includes("/files")) {
-        return Promise.resolve(augmentAxiosResponse(resources["allfiles"]));
-      } else if (url.includes("/sites")) {
-        // sites
-        return Promise.resolve(augmentAxiosResponse(resources["sites"]));
-      } else if (url.includes("/search")) {
-        // search
-        return Promise.resolve(augmentAxiosResponse(resources["allsearch"]));
-      } else if (url.includes("/products")) {
-        return Promise.resolve(augmentAxiosResponse(resources["products-with-variables"]));
+
+    const defaultAxiosMock = async (url: string): Promise<AxiosResponse> => {
+      const resourceMappings: Record<string, string> = {
+        "/files": "allfiles",
+        "/sites": "sites",
+        "/search": "allsearch",
+        "/products": "products-with-variables",
+        "/instruments": "instruments",
+      };
+      const resourceKey = Object.keys(resourceMappings).find((key) => url.includes(key));
+      if (resourceKey) {
+        return augmentAxiosResponse(resources[resourceMappings[resourceKey]]);
       }
-      return Promise.reject(new Error(`Unmocked URL: ${url}`));
+      throw new Error(`Unmocked URL: ${url}`);
     };
+
     vi.mocked(axios.get).mockImplementation(defaultAxiosMock);
 
     router.push("/search/data");

--- a/shared/lib/entity/File.ts
+++ b/shared/lib/entity/File.ts
@@ -5,6 +5,7 @@ import type { Model } from "./Model";
 import type { ModelVisualization } from "./ModelVisualization";
 import type { ErrorLevel } from "./QualityReport";
 import type { Software } from "./Software";
+import type { Instrument } from "./Instrument";
 
 export enum Quality {
   NRT = "nrt",
@@ -37,6 +38,7 @@ export interface RegularFile extends File {
   sourceFileIds: string[] | null;
   visualizations: Visualization[];
   instrumentPid: string;
+  instrument: Instrument;
 }
 
 export interface ModelFile extends File {

--- a/shared/lib/entity/Instrument.ts
+++ b/shared/lib/entity/Instrument.ts
@@ -14,4 +14,5 @@ export interface Instrument {
   humanReadableName: string;
   uploads: InstrumentUpload[];
   calibrations: Calibration[];
+  shortName: string;
 }


### PR DESCRIPTION
This PR:
- Adds support to have several Level 1b files of the same type (e.g. "radar") for one day / site.
- Adds instrument filter to GUI
- Adds shortName property to instruments

New API arguments:
- /api/raw-files - `instrumentPid`, `instrument`
- /api/files - `instrumentPid`, `instrument`
- /api/search/ - `instrument`
- /api/visualizations/ - `instrument`