### PR TITLE
L3 batch tasks

### DIFF
--- a/backend/src/entity/VisualizationResponse.ts
+++ b/backend/src/entity/VisualizationResponse.ts
@@ -14,6 +14,7 @@ export interface VisualizationItem {
 export class VisualizationResponse {
   sourceFileId: string;
   locationHumanReadable: string;
+  productId: string;
   productHumanReadable: string;
   volatile: boolean;
   legacy: boolean;
@@ -44,12 +45,13 @@ export class VisualizationResponse {
           : null,
     }));
     if (file instanceof RegularFile) {
-      this.source = file.instrumentInfo;
+      this.source = file.instrumentInfo ?? file.model;
     } else if (file instanceof ModelFile) {
       this.source = file.model;
     } else {
       this.source = null;
     }
+    this.productId = file.product.id;
     this.productHumanReadable = file.product.humanReadableName;
     this.locationHumanReadable = file.site.humanReadableName;
     this.volatile = file.volatile;

--- a/backend/src/lib/queue.ts
+++ b/backend/src/lib/queue.ts
@@ -339,7 +339,7 @@ export class QueueService {
     const allowedKeys = ["derivedProducts"];
     for (const key in output) {
       if (!allowedKeys.includes(key)) {
-        throw new Error(`Unknown key ${key}`);
+        throw new Error(`Unknown option: ${key}`);
       }
     }
     if (typeof output.derivedProducts !== "undefined") {

--- a/backend/src/routes/queue.ts
+++ b/backend/src/routes/queue.ts
@@ -30,16 +30,17 @@ export class QueueRoutes {
 
   submitBatch: RequestHandler = async (req, res, next) => {
     const searchParams = req.body;
-    const paramErrors = await Promise.all([
-      this.checkParam(this.siteRepo, "id", searchParams, "siteIds"),
-      this.checkParam(this.productRepo, "id", searchParams, "productIds"),
-      this.checkParam(this.instrumentRepo, "id", searchParams, "instrumentIds"),
-      this.checkParam(this.modelRepo, "id", searchParams, "modelIds"),
-      this.checkParam(this.instrumentInfoRepo, "uuid", searchParams, "instrumentUuids"),
-    ]);
-    const paramError = paramErrors.find((error) => error !== null);
-    if (paramError) {
-      return next({ status: 400, errors: paramError });
+    try {
+      await Promise.all([
+        this.checkParam(this.siteRepo, "id", searchParams, "siteIds"),
+        this.checkParam(this.productRepo, "id", searchParams, "productIds"),
+        this.checkParam(this.instrumentRepo, "id", searchParams, "instrumentIds"),
+        this.checkParam(this.modelRepo, "id", searchParams, "modelIds"),
+        this.checkParam(this.instrumentInfoRepo, "uuid", searchParams, "instrumentUuids"),
+      ]);
+      searchParams.options = this.queueService.validateTaskOptions(searchParams.type, searchParams.options);
+    } catch (error: any) {
+      return next({ status: 400, errors: error.message || "Unknown error" });
     }
     if (searchParams.modelIds) {
       if (!("productIds" in searchParams)) {
@@ -49,7 +50,6 @@ export class QueueRoutes {
       }
     }
 
-    searchParams.options = this.queueService.validateTaskOptions(searchParams.type, searchParams.options);
     const batchId = randomName();
     const batches = [];
     batches.push(this.submitInstrumentBatch(searchParams, batchId));
@@ -336,18 +336,17 @@ export class QueueRoutes {
     }
   }
 
-  private async checkParam(repo: any, column: string, searchParams: any, key: string): Promise<string | null> {
+  private async checkParam(repo: any, column: string, searchParams: any, key: string) {
     if (!(key in searchParams)) return null;
     if (!isStringArray(searchParams[key])) {
-      return `${key} should be string array`;
+      throw new Error(`${key} should be string array`);
     }
     const objs = await repo.find({ where: { [column]: In(searchParams[key]) }, select: [column] });
     const validIds = new Set(objs.map((obj: any) => obj[column]));
     const invalidIds = searchParams[key].filter((id: any) => !validIds.has(id));
     if (invalidIds.length > 0) {
-      return `Invalid ${key}: ${invalidIds.join(", ")}`;
+      throw new Error(`Invalid ${key}: ${invalidIds.join(", ")}`);
     }
-    return null;
   }
 
   /// Recursively find all possible source instruments for a given product.

--- a/backend/src/routes/queue.ts
+++ b/backend/src/routes/queue.ts
@@ -62,8 +62,13 @@ export class QueueRoutes {
         relations: { sourceProducts: true },
       });
       for (const product of products) {
-        if (product.sourceProducts.length === 0) continue;
-        batches.push(this.submitProductBatch(searchParams, batchId, product));
+        if (product.id.startsWith("l3-")) {
+          if (!searchParams.instrumentIds && !searchParams.instrumentUuids) {
+            batches.push(this.submitEvaluationBatch(searchParams, batchId, product));
+          }
+        } else if (product.sourceProducts.length > 0) {
+          batches.push(this.submitProductBatch(searchParams, batchId, product));
+        }
       }
     }
     const counts = await Promise.all(batches);
@@ -220,16 +225,22 @@ export class QueueRoutes {
   }
 
   private async submitModelBatch(filters: Record<string, any>, batchId: string) {
-    const where = [];
-    const parameters = [];
-    if (filters.modelIds) {
-      where.push(`upload."modelId" = ANY ($${parameters.length + 1})`);
-      parameters.push(filters.modelIds);
-    }
-    return this.batchQuery(filters, where, parameters, {
+    return this.batchQuery(filters, [], [], {
       table: "model_upload",
       batchId,
       productId: "'model'::text",
+      modelId: `upload."modelId"`,
+    });
+  }
+
+  /// Submit batch for an L3 product: task per model with a processed model file.
+  private async submitEvaluationBatch(filters: Record<string, any>, batchId: string, product: Product) {
+    const where = [`upload."tombstoneReason" IS NULL`];
+    const parameters = [product.id];
+    return this.batchQuery(filters, where, parameters, {
+      table: "model_file",
+      batchId,
+      productId: "$1::text",
       modelId: `upload."modelId"`,
     });
   }
@@ -272,6 +283,10 @@ export class QueueRoutes {
     if (searchParams.siteIds) {
       where.push(`upload."siteId" = ANY ($${parameters.length + 1})`);
       parameters.push(searchParams.siteIds);
+    }
+    if (searchParams.modelIds && options.modelId) {
+      where.push(`${options.modelId} = ANY ($${parameters.length + 1})`);
+      parameters.push(searchParams.modelIds);
     }
     if (searchParams.date) {
       where.push(`upload."measurementDate" = $${parameters.length + 1}`);

--- a/backend/src/routes/queue.ts
+++ b/backend/src/routes/queue.ts
@@ -1,4 +1,4 @@
-import { NextFunction, RequestHandler } from "express";
+import { RequestHandler } from "express";
 import { QueueService } from "../lib/queue";
 import { isTaskStatus, Task, TaskStatus } from "../entity/Task";
 import { DataSource, In, Repository } from "typeorm";
@@ -30,13 +30,17 @@ export class QueueRoutes {
 
   submitBatch: RequestHandler = async (req, res, next) => {
     const searchParams = req.body;
-    await Promise.all([
-      this.checkParam(this.siteRepo, "id", searchParams, "siteIds", next),
-      this.checkParam(this.productRepo, "id", searchParams, "productIds", next),
-      this.checkParam(this.instrumentRepo, "id", searchParams, "instrumentIds", next),
-      this.checkParam(this.modelRepo, "id", searchParams, "modelIds", next),
-      this.checkParam(this.instrumentInfoRepo, "uuid", searchParams, "instrumentUuids", next),
+    const paramErrors = await Promise.all([
+      this.checkParam(this.siteRepo, "id", searchParams, "siteIds"),
+      this.checkParam(this.productRepo, "id", searchParams, "productIds"),
+      this.checkParam(this.instrumentRepo, "id", searchParams, "instrumentIds"),
+      this.checkParam(this.modelRepo, "id", searchParams, "modelIds"),
+      this.checkParam(this.instrumentInfoRepo, "uuid", searchParams, "instrumentUuids"),
     ]);
+    const paramError = paramErrors.find((error) => error !== null);
+    if (paramError) {
+      return next({ status: 400, errors: paramError });
+    }
     if (searchParams.modelIds) {
       if (!("productIds" in searchParams)) {
         searchParams.productIds = ["model"];
@@ -332,17 +336,18 @@ export class QueueRoutes {
     }
   }
 
-  private async checkParam(repo: any, column: string, searchParams: any, key: string, next: NextFunction) {
-    if (!(key in searchParams)) return;
+  private async checkParam(repo: any, column: string, searchParams: any, key: string): Promise<string | null> {
+    if (!(key in searchParams)) return null;
     if (!isStringArray(searchParams[key])) {
-      return next({ status: 400, errors: `${key} should be string array` });
+      return `${key} should be string array`;
     }
     const objs = await repo.find({ where: { [column]: In(searchParams[key]) }, select: [column] });
     const validIds = new Set(objs.map((obj: any) => obj[column]));
     const invalidIds = searchParams[key].filter((id: any) => !validIds.has(id));
     if (invalidIds.length > 0) {
-      return next({ status: 400, errors: `Invalid ${key}: ${invalidIds.join(", ")}` });
+      return `Invalid ${key}: ${invalidIds.join(", ")}`;
     }
+    return null;
   }
 
   /// Recursively find all possible source instruments for a given product.

--- a/backend/src/routes/visualization.ts
+++ b/backend/src/routes/visualization.ts
@@ -78,7 +78,8 @@ export class VisualizationRoutes {
         .leftJoinAndSelect("file.product", "product")
         .where("file.uuid = :uuid", params)
         .addOrderBy("product_variable.order", "ASC");
-      if (isModel) qb.leftJoinAndSelect("file.model", "model");
+      // Evaluation regular files also have a model relation.
+      qb.leftJoinAndSelect("file.model", "model");
       if (!isModel) {
         qb.leftJoinAndSelect("file.instrumentInfo", "instrumentInfo");
         qb.leftJoinAndSelect("instrumentInfo.instrument", "instrument");

--- a/backend/tests/integration/sequential/queue.test.ts
+++ b/backend/tests/integration/sequential/queue.test.ts
@@ -903,7 +903,18 @@ describe("/api/queue/batch", () => {
   it("rejects invalid parameters without creating tasks", async () => {
     await expect(
       axios.post(batchUrl, { type: "process", productIds: ["lidar", "kaboom"], dryRun: false }, { auth }),
-    ).rejects.toMatchObject({ response: { status: 400 } });
+    ).rejects.toMatchObject({ response: { status: 400, data: { errors: "Invalid productIds: kaboom" } } });
+    expect(await taskRepo.count()).toBe(0);
+  });
+
+  it("rejects invalid options without creating tasks", async () => {
+    await expect(
+      axios.post(
+        batchUrl,
+        { type: "process", productIds: ["lidar"], options: { msg: "Hello" }, dryRun: false },
+        { auth },
+      ),
+    ).rejects.toMatchObject({ response: { status: 400, data: { errors: "Unknown option: msg" } } });
     expect(await taskRepo.count()).toBe(0);
   });
 

--- a/backend/tests/integration/sequential/queue.test.ts
+++ b/backend/tests/integration/sequential/queue.test.ts
@@ -900,6 +900,13 @@ describe("/api/queue/batch", () => {
     ).rejects.toMatchObject({ response: { status: 401 } });
   });
 
+  it("rejects invalid parameters without creating tasks", async () => {
+    await expect(
+      axios.post(batchUrl, { type: "process", productIds: ["lidar", "kaboom"], dryRun: false }, { auth }),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+    expect(await taskRepo.count()).toBe(0);
+  });
+
   it("returns task count on dry run", async () => {
     const res = await axios.post(batchUrl, { type: "process", productIds: ["lidar"], dryRun: true }, { auth });
     expect(res.data).toEqual({ taskCount: 2 });

--- a/backend/tests/integration/sequential/queue.test.ts
+++ b/backend/tests/integration/sequential/queue.test.ts
@@ -992,6 +992,55 @@ describe("/api/queue/batch", () => {
     expect(await taskRepo.countBy({ modelId: "icon-iglo-12-23" })).toBe(2);
   });
 
+  it("creates L3 tasks", async () => {
+    await axios.post(batchUrl, { type: "process", productIds: ["l3-cf"], dryRun: false }, { auth });
+    expect(await taskRepo.count()).toBe(6);
+    expect(await taskRepo.countBy({ productId: "l3-cf", modelId: "ecmwf" })).toBe(4);
+    expect(await taskRepo.countBy({ productId: "l3-cf", modelId: "icon-iglo-12-23" })).toBe(2);
+    expect(
+      await taskRepo.existsBy({
+        measurementDate: new Date("2020-01-26"),
+        siteId: "granada",
+        productId: "l3-cf",
+        modelId: "ecmwf",
+        instrumentInfoUuid: IsNull(),
+        options: { derivedProducts: true },
+      }),
+    ).toBeTruthy();
+  });
+
+  it("creates L3 tasks filtered by model", async () => {
+    await axios.post(
+      batchUrl,
+      { type: "process", productIds: ["l3-iwc"], modelIds: ["icon-iglo-12-23"], dryRun: false },
+      { auth },
+    );
+    expect(await taskRepo.count()).toBe(2);
+    expect(await taskRepo.countBy({ productId: "l3-iwc", modelId: "icon-iglo-12-23" })).toBe(2);
+    expect(await taskRepo.countBy({ siteId: "bucharest", productId: "l3-iwc" })).toBe(2);
+  });
+
+  it("creates L3 tasks filtered by site and date", async () => {
+    await axios.post(
+      batchUrl,
+      { type: "process", productIds: ["l3-lwc"], siteIds: ["bucharest"], dateFrom: "2020-12-01", dryRun: false },
+      { auth },
+    );
+    expect(await taskRepo.count()).toBe(2);
+    const task = { measurementDate: new Date("2020-12-05"), siteId: "bucharest", productId: "l3-lwc" };
+    expect(await taskRepo.existsBy({ ...task, modelId: "ecmwf" })).toBeTruthy();
+    expect(await taskRepo.existsBy({ ...task, modelId: "icon-iglo-12-23" })).toBeTruthy();
+  });
+
+  it("does not create L3 tasks when filtering by instrument", async () => {
+    await axios.post(
+      batchUrl,
+      { type: "process", productIds: ["l3-cf"], instrumentIds: ["halo-doppler-lidar"], dryRun: false },
+      { auth },
+    );
+    expect(await taskRepo.count()).toBe(0);
+  });
+
   it("creates categorize tasks", async () => {
     await axios.post(batchUrl, { type: "process", productIds: ["categorize"], dryRun: false }, { auth });
     expect(await taskRepo.count()).toBe(5);

--- a/frontend/src/components/VizSearchResult.vue
+++ b/frontend/src/components/VizSearchResult.vue
@@ -30,13 +30,7 @@
             title="View data object"
             class="sourceFileLink"
           >
-            {{
-              file.source !== null
-                ? "humanReadableName" in file.source
-                  ? file.source.humanReadableName
-                  : `${file.source.name} ${file.source.type}`
-                : file.productHumanReadable
-            }}, {{ file.locationHumanReadable }}
+            {{ sourceFileTitle(file) }}, {{ file.locationHumanReadable }}
             <svg fill="#000000" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="60px" height="60px">
               <path
                 d="M 25.980469 2.9902344 A 1.0001 1.0001 0 0 0 25.869141 3 L 20 3 A 1.0001 1.0001 0 1 0 20 5 L 23.585938 5 L 13.292969 15.292969 A 1.0001 1.0001 0 1 0 14.707031 16.707031 L 25 6.4140625 L 25 10 A 1.0001 1.0001 0 1 0 27 10 L 27 4.1269531 A 1.0001 1.0001 0 0 0 25.980469 2.9902344 z M 6 7 C 4.9069372 7 4 7.9069372 4 9 L 4 24 C 4 25.093063 4.9069372 26 6 26 L 21 26 C 22.093063 26 23 25.093063 23 24 L 23 14 L 23 11.421875 L 21 13.421875 L 21 16 L 21 24 L 6 24 L 6 9 L 14 9 L 16 9 L 16.578125 9 L 18.578125 7 L 16 7 L 14 7 L 6 7 z"
@@ -88,6 +82,13 @@ let requestController: AbortController | null = null;
 const isBusy = ref(true);
 const error = ref("");
 const apiResponse = ref<VisualizationResponse[]>([]);
+
+function sourceFileTitle(file: VisualizationResponse): string {
+  if (file.source === null) return file.productHumanReadable;
+  if (!("humanReadableName" in file.source)) return `${file.source.name} ${file.source.type}`;
+  if (file.productId === "model") return file.source.humanReadableName;
+  return `${file.productHumanReadable} (${file.source.humanReadableName})`;
+}
 
 const noSelectionsMade = computed(
   () =>

--- a/frontend/src/components/VizSearchResult.vue
+++ b/frontend/src/components/VizSearchResult.vue
@@ -87,7 +87,7 @@ function sourceFileTitle(file: VisualizationResponse): string {
   if (file.source === null) return file.productHumanReadable;
   if (!("humanReadableName" in file.source)) return `${file.source.name} ${file.source.type}`;
   if (file.productId === "model") return file.source.humanReadableName;
-  return `${file.productHumanReadable} (${file.source.humanReadableName})`;
+  return `${file.productHumanReadable}, ${file.source.humanReadableName}`;
 }
 
 const noSelectionsMade = computed(

--- a/shared/lib/entity/VisualizationResponse.ts
+++ b/shared/lib/entity/VisualizationResponse.ts
@@ -12,6 +12,7 @@ export interface VisualizationItem {
 export interface VisualizationResponse {
   sourceFileId: string;
   locationHumanReadable: string;
+  productId: string;
   productHumanReadable: string;
   volatile: boolean;
   legacy: boolean;


### PR DESCRIPTION
**Support L3 products in batch submission**

- Add L3 support to the batch endpoint: one task per model with a processed model file for the day.
- Fix a pre-existing bug (?) where invalid batch parameters returned a 400 but still created tasks.
- Show the model name in visualisation view titles for L3 products, e.g. "L3 Ice water content (ECMWF forecast), Lindenberg", so plots from different models can be told apart.